### PR TITLE
Fix get wasm metadata

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "GPL-3.0",
       "dependencies": {
         "@polkadot/api": "^6.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/api/src/WasmMeta.ts
+++ b/api/src/WasmMeta.ts
@@ -36,13 +36,13 @@ export async function getWasmMetadata(wasmBytes: Buffer): Promise<Metadata> {
   };
 
   let module = await WebAssembly.instantiate(wasmBytes, importObj);
-
-  metadata.types = `0x${readMeta(memory, module.instance.exports.meta_registry)}`;
-  metadata.init_input = readMeta(memory, module.instance.exports.meta_init_input);
-  metadata.init_output = readMeta(memory, module.instance.exports.meta_init_output);
-  metadata.input = readMeta(memory, module.instance.exports.meta_input);
-  metadata.output = readMeta(memory, module.instance.exports.meta_output);
-  metadata.title = readMeta(memory, module.instance.exports.meta_title);
+  const instance = module.instance.exports;
+  metadata.types = instance?.meta_registry ? `0x${readMeta(memory, instance.meta_registry)}` : '';
+  metadata.init_input = instance?.meta_init_input ? readMeta(memory, instance.meta_init_input) : '';
+  metadata.init_output = instance?.meta_init_output ? readMeta(memory, instance.meta_init_output) : '';
+  metadata.input = instance?.meta_input ? readMeta(memory, instance.meta_input) : '';
+  metadata.output = instance?.meta_output ? readMeta(memory, instance.meta_output) : '';
+  metadata.title = instance?.meta_title ? readMeta(memory, instance.meta_title) : '';
 
   return metadata;
 }


### PR DESCRIPTION
Fixes # .

- Getting metadata from .meta.wasm if some fileds is not specified 
- Update package version

