### PR TITLE
Add node info (api)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -33,6 +33,14 @@ You can also connect to a different node
 const gearApi = await GearApi.create({ provider: 'wss://someIP:somePort' });
 ```
 
+Getting node info
+
+```javascript
+const chain = await gearApi.chain();
+const nodeName = await gearApi.nodeName();
+const version = await gearApi.version();
+```
+
 Registering custom types
 
 ```javascript

--- a/api/src/Events.ts
+++ b/api/src/Events.ts
@@ -24,7 +24,7 @@ export class GearEvents {
     } catch (error) {}
   }
 
-  subsribeProgramEvents(callback: (event: Event) => void | Promise<void>): UnsubscribePromise {
+  subscribeProgramEvents(callback: (event: Event) => void | Promise<void>): UnsubscribePromise {
     try {
       return this.api.query.system.events((events) => {
         events

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -77,4 +77,16 @@ export class GearApi {
   async totalIssuance(): Promise<string> {
     return (await this.api.query.balances.totalIssuance()).toHuman();
   }
+
+  async chain(): Promise<string> {
+    return (await this.api.rpc.system.chain()).toHuman();
+  }
+
+  async nodeName(): Promise<string> {
+    return (await this.api.rpc.system.name()).toHuman();
+  }
+
+  async nodeVersion(): Promise<string> {
+    return (await this.api.rpc.system.version()).toHuman();
+  }
 }


### PR DESCRIPTION
Add getting node info

Using:

```javascript
import { gearApi } from '@gear-js/api';
const gearApi = await GearApi.create();
const chain = await gearApi.chain();
const nodeName = await gearApi.nodeName();
const version = await gearApi.version();
```