### PR TITLE
Add subscribing to transfer balance events (api)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -114,6 +114,16 @@ const unsub = await gearApi.gearEvents.subscribeProgramEvents((event) => {
 unsub();
 ```
 
+Subscribe to Transfer events
+
+```javascript
+const unsub = await gearApi.gearEvents.subscribeTransferEvents((event) => {
+  console.log(event.toHuman());
+});
+// Unsubscribe
+unsub();
+```
+
 Subscribe to new blocks
 
 ```javascript

--- a/api/src/Events.ts
+++ b/api/src/Events.ts
@@ -21,7 +21,9 @@ export class GearEvents {
             }, 100);
           });
       });
-    } catch (error) {}
+    } catch (error) {
+      throw error;
+    }
   }
 
   subscribeProgramEvents(callback: (event: Event) => void | Promise<void>): UnsubscribePromise {
@@ -37,10 +39,26 @@ export class GearEvents {
             }, 100);
           });
       });
-    } catch (error) {}
+    } catch (error) {
+      throw error;
+    }
   }
 
-  async subscribeNewBlocks(callback: (header: Header) => void | Promise<void>): UnsubscribePromise {
+  subscribeTransferEvents(callback: (event: Event) => void | Promise<void>): UnsubscribePromise {
+    try {
+      return this.api.query.system.events((events) => {
+        events
+          .filter(({ event }) => this.api.events.balances.Transfer.is(event))
+          .forEach(({ event }) => {
+            callback(event);
+          });
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  subscribeNewBlocks(callback: (header: Header) => void | Promise<void>): UnsubscribePromise {
     try {
       return this.api.rpc.chain.subscribeNewHeads((header) => {
         callback(header);

--- a/api/src/Message.ts
+++ b/api/src/Message.ts
@@ -16,7 +16,7 @@ export class GearMessage {
     this.createType = new CreateType(gearApi);
   }
 
-  async submit(message: Message, meta: Metadata) {
+  submit(message: Message, meta: Metadata): any {
     let payload: Bytes | Uint8Array | string;
 
     payload = this.createType.encode(meta.input, message.payload, meta);

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -23,7 +23,7 @@ export class GearProgram {
    * @param meta Metadata
    * @returns ProgramId
    */
-  async submit(program: Program, meta: Metadata): Promise<string> {
+  submit(program: Program, meta: Metadata): string {
     if (program.initPayload) {
       program.initPayload = this.createType.encode(meta.init_input, program.initPayload, meta);
     } else {


### PR DESCRIPTION
Add subscribing to transfer events only

Use:

```javascript
const unsub = await gearApi.gearEvents.subscribeTransferEvents((event) => {
  console.log(event.toHuman());
});
```
