### PR TITLE
Remove .at method

### DIFF
--- a/api/api/package-lock.json
+++ b/api/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "mocha": "^9.1.1",

--- a/api/api/package.json
+++ b/api/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/api/api/src/types/EventData.ts
+++ b/api/api/src/types/EventData.ts
@@ -9,23 +9,23 @@ export class GearEventData extends GenericEventData {
 }
 export class MessageInfoData extends GearEventData {
   public get messageId(): H256 {
-    return this.at(0)['messageId'] as H256;
+    return this[0]['messageId'] as H256;
   }
   public get programId(): H256 {
-    return this.at(0)['programId'] as H256;
+    return this[0]['programId'] as H256;
   }
   public get origin(): H256 {
-    return this.at(0)['origin'] as H256;
+    return this[0]['origin'] as H256;
   }
 }
 
 export class ProgramData extends GearEventData {
   public get info(): MessageInfo {
-    return this.at(0) as MessageInfo;
+    return this[0] as MessageInfo;
   }
   public get reason(): Reason {
     if (this.length > 1) {
-      return this.at(1) as Reason;
+      return this[1] as Reason;
     }
     return null;
   }
@@ -33,38 +33,38 @@ export class ProgramData extends GearEventData {
 
 export class LogData extends GearEventData {
   public get id(): H256 {
-    return this.at(0)['id'];
+    return this[0]['id'];
   }
   public get source(): H256 {
-    return this.at(0)['source'];
+    return this[0]['source'];
   }
   public get dest(): H256 {
-    return this.at(0)['dest'];
+    return this[0]['dest'];
   }
   public get payload(): Vec<u8> {
-    return this.at(0)['payload'];
+    return this[0]['payload'];
   }
   public get gasLimit(): u64 {
-    return this.at(0)['gasLimit'];
+    return this[0]['gasLimit'];
   }
   public get value(): u128 {
-    return this.at(0)['value'];
+    return this[0]['value'];
   }
   public get reply(): Option<Reply> {
-    return this.at(0)['reply'];
+    return this[0]['reply'];
   }
 }
 
 export class TransferData extends GearEventData {
   public get from(): H256 {
-    return this.at(0) as H256;
+    return this[0] as H256;
   }
 
   public get to(): H256 {
-    return this.at(1) as H256;
+    return this[1] as H256;
   }
   public get value(): u128 {
-    return this.at(2) as u128;
+    return this[2] as u128;
   }
 }
 
@@ -75,10 +75,10 @@ export class InitFailureData extends ProgramData {}
 
 export class DebugData extends GearEventData {
   public get messageQueue(): Vec<Message> {
-    return this.at(0)['messageQueue'];
+    return this[0]['messageQueue'];
   }
 
   public get programs(): Vec<ProgramDetails> {
-    return this.at(0)['programs'];
+    return this[0]['programs'];
   }
 }


### PR DESCRIPTION
Fix:
- Remove .at method from @gear-js/api for using library in safari