### PR TITLE
Add `message.data` RPC method

### DIFF
--- a/website/api-gateway/src/api-gateway/api-gateway.service.ts
+++ b/website/api-gateway/src/api-gateway/api-gateway.service.ts
@@ -5,6 +5,7 @@ import { Logger } from '@nestjs/common';
 import {
   AddMetaParams,
   AddPayloadParams,
+  FindMessageParams,
   FindProgramParams,
   GetAllProgramsParams,
   GetIncomingMessagesParams,
@@ -17,6 +18,7 @@ import config from 'src/config/configuration';
 
 const logger = new Logger('ApiGatewayService');
 const configKafka = config().kafka;
+
 @Injectable()
 export class ApiGatewayService extends RpcMessageHandler implements OnModuleInit {
   constructor() {
@@ -49,6 +51,7 @@ export class ApiGatewayService extends RpcMessageHandler implements OnModuleInit
     'meta.get',
     'program.all',
     'message.all',
+    'message.data',
     'message.add.payload',
     'testBalance.get',
   ];
@@ -93,6 +96,9 @@ export class ApiGatewayService extends RpcMessageHandler implements OnModuleInit
     message: {
       all: (params: GetMessagesParams) => {
         return this.client.send('message.all', params);
+      },
+      data: (params: FindMessageParams) => {
+        return this.client.send('message.data', params);
       },
       incoming: (params: GetIncomingMessagesParams) => {
         return this.client.send('message.all', params);

--- a/website/api-gateway/src/interfaces/message.ts
+++ b/website/api-gateway/src/interfaces/message.ts
@@ -32,6 +32,8 @@ export interface GetMessagesParams extends RequestParams {
   offset?: number;
 }
 
+export interface FindMessageParams extends RequestParams, Pick<Message, 'id'> {}
+
 export interface GetIncomingMessagesParams extends RequestParams {
   destination?: string;
   isRead?: boolean;

--- a/website/data-storage/src/consumer/consumer.controller.ts
+++ b/website/data-storage/src/consumer/consumer.controller.ts
@@ -53,6 +53,12 @@ export class ConsumerController {
     return JSON.stringify(result);
   }
 
+  @MessagePattern('message.data')
+  async messageData(@Payload() payload) {
+    const result = await this.consumerService.message(payload.value);
+    return JSON.stringify(result);
+  }
+
   @MessagePattern('message.add.payload')
   async savePayload(@Payload() payload) {
     const result = await this.consumerService.addPayload(payload.value);

--- a/website/data-storage/src/consumer/consumer.service.ts
+++ b/website/data-storage/src/consumer/consumer.service.ts
@@ -11,6 +11,7 @@ import {
   AddPayloadParams,
   AllMessagesResult,
   GetMessagesParams,
+  FindMessageParams,
 } from 'src/interfaces';
 import { MessagesService } from 'src/messages/messages.service';
 import { MetadataService } from 'src/metadata/metadata.service';
@@ -138,6 +139,14 @@ export class ConsumerService {
         return await this.messageService.getIncoming(params);
       }
       return await this.messageService.getOutgoing(params);
+    } catch (error) {
+      return { error: error.message };
+    }
+  }
+
+  async message(params: FindMessageParams): Result<Message> {
+    try {
+      return await this.messageService.getMessage(params);
     } catch (error) {
       return { error: error.message };
     }

--- a/website/data-storage/src/interfaces/message.ts
+++ b/website/data-storage/src/interfaces/message.ts
@@ -32,6 +32,9 @@ export interface GetMessagesParams extends RequestParams {
   offset?: number;
 }
 
+export interface FindMessageParams extends RequestParams, Pick<Message, 'id'> {
+}
+
 export interface GetIncomingMessagesParams extends RequestParams {
   destination?: string;
   isRead?: boolean;

--- a/website/data-storage/src/messages/messages.service.ts
+++ b/website/data-storage/src/messages/messages.service.ts
@@ -5,7 +5,7 @@ import { Message } from './entities/message.entity';
 import { GearKeyring } from '@gear-js/api';
 import { SignNotVerified } from 'src/errors/signature';
 import { MessageNotFound } from 'src/errors/message';
-import { AddPayloadParams, AllMessagesResult, GetMessagesParams } from 'src/interfaces';
+import { AddPayloadParams, AllMessagesResult, FindMessageParams, GetMessagesParams } from 'src/interfaces';
 import { PAGINATION_LIMIT } from 'src/config/configuration';
 
 const logger = new Logger('MessageService');
@@ -116,6 +116,14 @@ export class MessagesService {
       messages: result,
       count: total,
     };
+  }
+
+  async getMessage(params: FindMessageParams): Promise<Message> {
+    const where = {
+      id: params.id,
+    };
+    const result = await this.messageRepo.findOne({ where });
+    return result;
   }
 
   async getCountUnread(destination: string): Promise<number> {


### PR DESCRIPTION
This PR adds JSONRPC method `message.data` to api gateway:

```
$ curl localhost:3000/api --data-binary '{
  "jsonrpc": "1.0",
  "id": "from-curl",
  "method": "message.data",
  "params":
    { "genesis": "0x...",
      "id": "0x..."
    }
}'
```
