### PR TITLE
Rework `ExecutionError` type

### DIFF
--- a/website/api-gateway/src/json-rpc/handler.ts
+++ b/website/api-gateway/src/json-rpc/handler.ts
@@ -78,18 +78,21 @@ export class RpcMessageHandler {
 
   executeMethod(method: (params: any) => Observable<any>, procedure: IRpcRequest) {
     const result = method(procedure.params);
-    if (result) {
-      return new Promise((resolve, reject) => {
-        result.forEach((value) => {
+    if (!result) {
+      return;
+    }
+    return new Promise((resolve) => {
+      result
+        .forEach((value) => {
           if (!value) {
             resolve(this.getResponse(procedure, { error: 'Service is not available' }));
-          } else if (value.error) {
-            resolve(this.getResponse(procedure, value));
+          } else if ('error' in value) {
+            resolve(this.getResponse(procedure, value.error));
           } else {
             resolve(this.getResponse(procedure, null, value));
           }
-        });
-      });
-    }
+        })
+        .finally(() => console.log('end'));
+    });
   }
 }

--- a/website/api-gateway/src/json-rpc/handler.ts
+++ b/website/api-gateway/src/json-rpc/handler.ts
@@ -82,17 +82,15 @@ export class RpcMessageHandler {
       return;
     }
     return new Promise((resolve) => {
-      result
-        .forEach((value) => {
-          if (!value) {
-            resolve(this.getResponse(procedure, { error: 'Service is not available' }));
-          } else if ('error' in value) {
-            resolve(this.getResponse(procedure, value.error));
-          } else {
-            resolve(this.getResponse(procedure, null, value));
-          }
-        })
-        .finally(() => console.log('end'));
+      result.forEach((value) => {
+        if (!value) {
+          resolve(this.getResponse(procedure, { error: 'Service is not available' }));
+        } else if ('error' in value) {
+          resolve(this.getResponse(procedure, value.error));
+        } else {
+          resolve(this.getResponse(procedure, null, value));
+        }
+      });
     });
   }
 }

--- a/website/data-storage/src/consumer/consumer.service.ts
+++ b/website/data-storage/src/consumer/consumer.service.ts
@@ -85,9 +85,9 @@ export class ConsumerService {
 
   async programData(params: FindProgramParams): Result<IProgram> {
     try {
-      return (await this.programService.findProgram(params)) || { error: new ProgramNotFound().message };
-    } catch (error) {
-      return { error: error.message };
+      return (await this.programService.findProgram(params)) || { error: { message: new ProgramNotFound().message } };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
@@ -97,8 +97,8 @@ export class ConsumerService {
         return await this.programService.getAllUserPrograms(params as GetAllUserProgramsParams);
       }
       return await this.programService.getAllPrograms(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
@@ -113,24 +113,24 @@ export class ConsumerService {
   async addMeta(params: AddMetaParams): Result<AddMetaResult> {
     try {
       return await this.metaService.addMeta(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
   async getMeta(params: GetMetaParams): Result<GetMetaResult> {
     try {
       return await this.metaService.getMeta(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
   async addPayload(params: AddPayloadParams): Result<IMessage> {
     try {
       return await this.messageService.addPayload(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
@@ -143,16 +143,16 @@ export class ConsumerService {
         return await this.messageService.getIncoming(params);
       }
       return await this.messageService.getOutgoing(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 
   async message(params: FindMessageParams): Result<IMessage> {
     try {
       return await this.messageService.getMessage(params);
-    } catch (error) {
-      return { error: error.message };
+    } catch ({ message }) {
+      return { error: { message } };
     }
   }
 }

--- a/website/data-storage/src/consumer/consumer.service.ts
+++ b/website/data-storage/src/consumer/consumer.service.ts
@@ -85,7 +85,7 @@ export class ConsumerService {
 
   async programData(params: FindProgramParams): Result<IProgram> {
     try {
-      return (await this.programService.findProgram(params)) || { error: { message: new ProgramNotFound().message } };
+      return (await this.programService.findProgram(params));
     } catch ({ message }) {
       return { error: { message } };
     }

--- a/website/data-storage/src/errors/interfaces.ts
+++ b/website/data-storage/src/errors/interfaces.ts
@@ -1,3 +1,3 @@
 export interface ExecutionError {
-  error: string;
+  error: { message: string };
 }

--- a/website/data-storage/src/programs/programs.service.ts
+++ b/website/data-storage/src/programs/programs.service.ts
@@ -10,8 +10,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Meta } from '../entities/meta.entity';
-import { Program } from '../entities/program.entity';
 import { ErrorLogger, getPaginationParams, getWhere } from '../utils';
+import { ProgramNotFound } from 'src/errors';
+import { Program } from 'src/entities/program.entity';
 
 const logger = new Logger('ProgramDb');
 const errorLog = new ErrorLogger('ProgramsService');
@@ -91,14 +92,14 @@ export class ProgramsService {
       return program;
     } catch (error) {
       logger.error(error, error.stack, '');
-      return null;
+      throw new ProgramNotFound(error.message);
     }
   }
 
   async setStatus(id: string, genesis: string, status: InitStatus): Promise<IProgram> {
     return new Promise((resolve) => {
       setTimeout(async () => {
-        let program = await this.findProgram({ id, genesis });
+        const program = await this.findProgram({ id, genesis });
         if (program) {
           program.initStatus = status;
           resolve(await this.programRepo.save(program));


### PR DESCRIPTION
This PR changes the JSONRPC response to nest error message in field `error.message`:
```
$ curl localhost:3000/api --data-binary ...
...
* upload completely sent off: 222 out of 222 bytes
< HTTP/1.1 201 Created
...
< 
* Connection #0 to host localhost left intact
{   "jsonrpc": "2.0",
    "id": "from-curl",
    "error": { "message": "it works" }
}
```