### PR TITLE
Specify payload as hex without metadata

### DIFF
--- a/.github/workflows/Publish-gear-api.yml
+++ b/.github/workflows/Publish-gear-api.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
     paths:
-      - api/api/**
+      - api/**
 
 jobs:
   build:
@@ -17,17 +17,19 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: 16.x
+
       - name: Check package version
         uses: EndBug/version-check@v1
         id: check
         with:
-          file-name: api/api/package.json
+          file-name: api/package.json
           file-url: https://unpkg.com/@gear-js/api@latest/package.json
           static-checking: localIsNew
+
       - name: Publish
         if: steps.check.outputs.changed == 'true'
+        working-directory: api
         run: |
-          cd api/api
           npm ci
           npm config set //registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN
           npm publish

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/CreateType.ts
+++ b/api/src/CreateType.ts
@@ -126,6 +126,11 @@ export class CreateType {
     }
   }
 
+  static create(type: any, payload: any, meta?: Metadata): Codec {
+    const createType = new CreateType();
+    return createType.create(type, payload, meta);
+  }
+
   static encode(type: any, payload: any, meta?: Metadata): Codec {
     const createType = new CreateType();
     return createType.create(type, payload, meta);

--- a/api/src/Message.ts
+++ b/api/src/Message.ts
@@ -1,5 +1,6 @@
 import { Metadata } from './interfaces';
 import { SendMessageError } from './errors';
+import { isHex } from '@polkadot/util';
 import { H256 } from '@polkadot/types/interfaces';
 import { AnyNumber } from '@polkadot/types/types';
 import { GearTransaction } from './types/Transaction';
@@ -11,7 +12,7 @@ export class GearMessage extends GearTransaction {
     meta?: Metadata,
     messageType?: string,
   ): any {
-    let payload: string = createPayload(this.createType, messageType || meta.handle_input, message.payload, meta);
+    let payload: string = createPayload(this.createType, messageType || meta?.handle_input, message.payload, meta);
 
     try {
       this.submitted = this.api.tx.gear.sendMessage(message.destination, payload, message.gasLimit, message.value || 0);

--- a/api/src/MessageReply.ts
+++ b/api/src/MessageReply.ts
@@ -26,7 +26,12 @@ export class GearMessageReply {
     meta?: Metadata,
     messageType?: string,
   ) {
-    let payload: string = createPayload(this.createType, messageType || meta.async_handle_input, message.payload, meta);
+    let payload: string = createPayload(
+      this.createType,
+      messageType || meta?.async_handle_input,
+      message.payload,
+      meta,
+    );
 
     try {
       this.reply = this.api.tx.gear.sendReply(message.toId, payload, message.gasLimit, message.value);

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -26,7 +26,7 @@ export class GearProgram extends GearTransaction {
   ): ProgramId {
     const salt = program.salt || randomAsHex(20);
     const code = this.createType.create('bytes', Array.from(program.code)) as Bytes;
-    let payload: string = createPayload(this.createType, messageType || meta.init_input, program.initPayload, meta);
+    let payload: string = createPayload(this.createType, messageType || meta?.init_input, program.initPayload, meta);
     try {
       this.submitted = this.api.tx.gear.submitProgram(code, salt, payload, program.gasLimit, program.value || 0);
       const programId = this.generateProgramId(code, salt);

--- a/api/src/State.ts
+++ b/api/src/State.ts
@@ -81,7 +81,7 @@ export class GearProgramState {
   }
 
   /**
-   * Read state of program
+   * Read state of particular program
    * @param programId
    * @param metaWasm - file with metadata
    * @returns decoded state

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,3 +1,4 @@
+import '@polkadot/api-augment';
 export { GearApi } from './GearApi';
 export { GearKeyring } from './Keyring';
 export { GearEvents } from './Events';
@@ -13,5 +14,3 @@ export { GearProgramState } from './State';
 export * from './interfaces';
 export * from './types';
 export * from './utils';
-
-import '@polkadot/api-augment';

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -56,8 +56,11 @@ export function splitByCommas(str: string) {
 }
 
 export function createPayload(createType: CreateType, type: any, data: any, meta?: Metadata) {
-  if (!data) {
-    return '0x00';
+  if (data === undefined) {
+    return '';
+  }
+  if (isHex(data)) {
+    return data;
   }
   let payload: string = data;
   if (meta && type) {

--- a/api/test/spec/programs/guestbook.yaml
+++ b/api/test/spec/programs/guestbook.yaml
@@ -26,6 +26,7 @@ messages:
         msg: Goodbye World!
     gasLimit: 50000000
     account: alice
+    asHex: true
 
   - id: 3
     program: 1

--- a/api/tsconfig.base.json
+++ b/api/tsconfig.base.json
@@ -13,7 +13,8 @@
     "paths": {
       "@polkadot/api/augment": ["src/interfaces/augment-api.ts"],
       "@polkadot/types/augment": ["src/interfaces/augment-types.ts"],
-      "@polkadot/api/types/storage": ["src/interfaces/augment-api-query.ts"]
+      "@polkadot/api/types/storage": ["src/interfaces/augment-api-query.ts"],
+      "@polkadot/rpc-core/types/jsonrpc": ["src/interfaces/augment-api-rpc.ts"]
     }
   },
   "exclude": ["test", "examples", "node_modules", "dist"],


### PR DESCRIPTION
- Added opportunity to specify payload as hex in `Send Message`, `Submit program`, `Message reply`
- Added test