### PR TITLE
Fix tests and dependencies

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.9.8",
+      "version": "0.10.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/Balance.ts
+++ b/api/src/Balance.ts
@@ -1,9 +1,10 @@
-import { GearApi, GearKeyring } from '.';
+import { GearApi } from './GearApi';
+import { GearKeyring } from './Keyring';
 import { TransactionError } from './errors';
+import { ISystemAccountInfo } from './interfaces';
 import { Balance } from '@polkadot/types/interfaces';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { BN } from '@polkadot/util';
-import { ISystemAccountInfo } from './interfaces';
 
 export class GearBalance {
   private api: GearApi;

--- a/api/src/CreateType.ts
+++ b/api/src/CreateType.ts
@@ -1,11 +1,11 @@
-import { GearApi } from '.';
+import { GearApi } from './GearApi';
 import { Metadata } from './interfaces';
 import { CreateTypeError } from './errors';
+import { toCamelCase, splitByCommas, toJSON, isJSON } from './utils';
 import { isHex, hexToU8a, isU8a } from '@polkadot/util';
 import { Registry, Codec } from '@polkadot/types/types';
 import { Bytes, TypeRegistry } from '@polkadot/types';
 import { PortableRegistry } from '@polkadot/types/metadata';
-import { toCamelCase, splitByCommas, toJSON, isJSON } from './utils';
 
 const REGULAR_EXP = {
   endWord: /\b\w+\b/g,

--- a/api/src/DebugMode.ts
+++ b/api/src/DebugMode.ts
@@ -1,7 +1,7 @@
 import { UnsubscribePromise } from '@polkadot/api/types';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { Codec } from '@polkadot/types-codec/types';
-import { DebugDataSnapshotEvent, GearApi } from '.';
+import { GearApi } from './GearApi';
+import { DebugDataSnapshotEvent } from './types';
 
 export class DebugMode {
   api: GearApi;

--- a/api/src/Events.ts
+++ b/api/src/Events.ts
@@ -1,4 +1,5 @@
-import { GearApi, IBalanceCallback, IBlocksCallback, IEventCallback } from '.';
+import { GearApi } from './GearApi';
+import { IBalanceCallback, IBlocksCallback, IEventCallback } from './interfaces';
 import { LogEvent, ProgramEvent, TransferEvent } from './types';
 import { UnsubscribePromise } from '@polkadot/api/types';
 import { ISystemAccountInfo } from './interfaces/system';

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -1,12 +1,10 @@
-import {
-  GearProgram,
-  GearMessage,
-  transformTypes,
-  GearBalance,
-  GearEvents,
-  GearMessageReply,
-  GearProgramState,
-} from '.';
+import { GearProgram } from './Program';
+import { GearMessage } from './Message';
+import { GearBalance } from './Balance';
+import { GearEvents } from './Events';
+import { GearProgramState } from './State';
+import { GearMessageReply } from './MessageReply';
+import { transformTypes } from './utils';
 import { gearRpc, gearTypes } from './default';
 import { GearApiOptions } from './interfaces';
 import { ApiPromise, WsProvider } from '@polkadot/api';

--- a/api/src/Mailbox.ts
+++ b/api/src/Mailbox.ts
@@ -1,4 +1,5 @@
-import { GearApi, Message } from '.';
+import { GearApi } from './GearApi';
+import { Message } from './interfaces';
 import { Option, BTreeMap } from '@polkadot/types';
 import { AccountId32, H256 } from '@polkadot/types/interfaces';
 

--- a/api/src/Message.ts
+++ b/api/src/Message.ts
@@ -1,11 +1,9 @@
 import { Metadata } from './interfaces';
 import { SendMessageError } from './errors';
-import { isHex } from '@polkadot/util';
+import { GearTransaction } from './types';
+import { createPayload } from './utils';
 import { H256 } from '@polkadot/types/interfaces';
 import { AnyNumber } from '@polkadot/types/types';
-import { GearTransaction } from './types/Transaction';
-import { createPayload } from '.';
-
 export class GearMessage extends GearTransaction {
   submit(
     message: { destination: string | H256; payload: string | any; gasLimit: AnyNumber; value?: AnyNumber },

--- a/api/src/MessageReply.ts
+++ b/api/src/MessageReply.ts
@@ -1,4 +1,6 @@
-import { GearApi, CreateType, createPayload } from '.';
+import { GearApi } from './GearApi';
+import { CreateType } from './CreateType';
+import { createPayload } from './utils';
 import { Metadata } from './interfaces';
 import { SendReplyError, TransactionError } from './errors';
 import { u64 } from '@polkadot/types';

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -4,8 +4,8 @@ import { AnyNumber } from '@polkadot/types/types';
 import { Bytes, U64, u64 } from '@polkadot/types';
 import { H256, BalanceOf } from '@polkadot/types/interfaces';
 import { randomAsHex, blake2AsU8a } from '@polkadot/util-crypto';
-import { GearTransaction } from './types/Transaction';
-import { createPayload } from '.';
+import { GearTransaction } from './types';
+import { createPayload } from './utils';
 
 export class GearProgram extends GearTransaction {
   /**

--- a/api/src/State.ts
+++ b/api/src/State.ts
@@ -1,4 +1,7 @@
-import { CreateType, GearApi, getWasmMetadata, IGearPages, IProgram, ProgramId } from '.';
+import { GearApi } from './GearApi';
+import { CreateType } from './CreateType';
+import { getWasmMetadata } from './WasmMeta';
+import { IGearPages, IProgram, ProgramId } from './interfaces';
 import { u32, Option, Raw } from '@polkadot/types';
 import { Codec } from '@polkadot/types/types';
 import { ReadStateError } from './errors/state.errors';

--- a/api/src/errors/message.errors.ts
+++ b/api/src/errors/message.errors.ts
@@ -1,4 +1,4 @@
-import { GearError } from '.';
+import { GearError } from './gear.errors';
 
 export class SendMessageError extends GearError {
   name = 'SendMessageError';

--- a/api/src/errors/program.errors.ts
+++ b/api/src/errors/program.errors.ts
@@ -1,4 +1,4 @@
-import { GearError } from '.';
+import { GearError } from './gear.errors';
 
 export class SubmitProgramError extends GearError {
   name = 'SubmitProgramError';

--- a/api/src/errors/state.errors.ts
+++ b/api/src/errors/state.errors.ts
@@ -1,4 +1,4 @@
-import { GearError } from '.';
+import { GearError } from './gear.errors';
 
 export class ReadStateError extends GearError {
   name = 'ReadStateError';

--- a/api/src/interfaces/gear-api.ts
+++ b/api/src/interfaces/gear-api.ts
@@ -1,4 +1,4 @@
-import { GearType } from '.';
+import { GearType } from './gear-type';
 import { i32, Bytes } from '@polkadot/types';
 import { H256 } from '@polkadot/types/interfaces';
 import { ApiOptions } from '@polkadot/api/types';

--- a/api/src/types/Event.ts
+++ b/api/src/types/Event.ts
@@ -10,6 +10,7 @@ import {
   ProgramData,
   TransferData,
 } from '.';
+import { MessageDispatchedData } from '..';
 
 export class GearEvent extends GenericEvent {
   constructor(event: Event) {
@@ -61,5 +62,11 @@ export class DispatchMessageEnqueuedEvent extends GearEvent {
 export class DebugDataSnapshotEvent extends GearEvent {
   public get data() {
     return new DebugData(this.get('data') as DebugData);
+  }
+}
+
+export class MessageDispatchedEvent extends GearEvent {
+  public get data() {
+    return new MessageDispatchedData(this.get('data') as MessageDispatchedData);
   }
 }

--- a/api/src/types/Event.ts
+++ b/api/src/types/Event.ts
@@ -9,8 +9,8 @@ import {
   LogData,
   ProgramData,
   TransferData,
-} from '.';
-import { MessageDispatchedData } from '..';
+  MessageDispatchedData,
+} from './EventData';
 
 export class GearEvent extends GenericEvent {
   constructor(event: Event) {

--- a/api/src/types/EventData.ts
+++ b/api/src/types/EventData.ts
@@ -1,7 +1,6 @@
 import { MessageInfo, Reason, Reply, Message, ProgramDetails } from '../';
 import { Vec, u64, u128, Option, u8, GenericEventData, Null, Bytes, Type } from '@polkadot/types';
 import { H256 } from '@polkadot/types/interfaces';
-import { Codec } from '@polkadot/types/types';
 
 export class GearEventData extends GenericEventData {
   constructor(data: GenericEventData) {

--- a/api/src/types/EventData.ts
+++ b/api/src/types/EventData.ts
@@ -1,6 +1,7 @@
 import { MessageInfo, Reason, Reply, Message, ProgramDetails } from '../';
-import { Vec, u64, u128, Option, u8, GenericEventData } from '@polkadot/types';
+import { Vec, u64, u128, Option, u8, GenericEventData, Null, Bytes, Type } from '@polkadot/types';
 import { H256 } from '@polkadot/types/interfaces';
+import { Codec } from '@polkadot/types/types';
 
 export class GearEventData extends GenericEventData {
   constructor(data: GenericEventData) {
@@ -80,5 +81,33 @@ export class DebugData extends GearEventData {
 
   public get programs(): Vec<ProgramDetails> {
     return this[0]['programs'];
+  }
+}
+
+export class ExecutionResult extends Type {
+  public get isSuccess(): boolean {
+    return this.isSuccess;
+  }
+
+  public get isFailure(): boolean {
+    return this.isFailure;
+  }
+
+  public get asSuccess(): Null {
+    return this.asSuccess;
+  }
+
+  public get asFailure(): Bytes {
+    return this.asFailure;
+  }
+}
+
+export class MessageDispatchedData extends GearEventData {
+  public get messageId(): H256 {
+    return this[0]['messageId'];
+  }
+
+  public get outcome(): ExecutionResult {
+    return this[0]['outcome'] as ExecutionResult;
   }
 }

--- a/api/src/types/EventData.ts
+++ b/api/src/types/EventData.ts
@@ -1,4 +1,4 @@
-import { MessageInfo, Reason, Reply, Message, ProgramDetails } from '../';
+import { MessageInfo, Reason, Reply, Message, ProgramDetails } from '../interfaces';
 import { Vec, u64, u128, Option, u8, GenericEventData, Null, Bytes, Type } from '@polkadot/types';
 import { H256 } from '@polkadot/types/interfaces';
 

--- a/api/src/types/Transaction.ts
+++ b/api/src/types/Transaction.ts
@@ -1,8 +1,10 @@
 import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from '@polkadot/api/types';
-import { CreateType, GearApi, TransactionStatusCb } from '../';
-import { isFunction } from '@polkadot/util';
+import { CreateType } from '../CreateType';
+import { GearApi } from '../GearApi';
+import { TransactionStatusCb } from '../interfaces';
 import { TransactionError } from '../errors';
-import { MessageInfoData } from '.';
+import { MessageInfoData } from './EventData';
+import { isFunction } from '@polkadot/util';
 
 export class GearTransaction {
   protected api: GearApi;

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Event';
 export * from './EventData';
+export * from './Transaction';

--- a/api/src/utils.ts
+++ b/api/src/utils.ts
@@ -1,7 +1,7 @@
 import { stringCamelCase, isHex } from '@polkadot/util';
 import { Text } from '@polkadot/types';
 import { Metadata } from './interfaces';
-import { CreateType } from '.';
+import { CreateType } from './CreateType';
 
 export function transformTypes(types: object): any {
   return Object.values(types).reduce((res, types): object => ({ ...res, ...types }), {});

--- a/api/test/ProgramsInteract.test.js
+++ b/api/test/ProgramsInteract.test.js
@@ -64,7 +64,7 @@ for (let filePath of testFiles) {
         if (program.log) {
           log = new Promise((resolve) => {
             unsubs.push(
-              api.gearEvents.subscribeLogEvents((event) => {
+              api.gearEvents.subscribeToLogEvents((event) => {
                 if (checkLog(event, programId, messageId)) {
                   resolve(event.data.payload.toHex());
                 }
@@ -75,7 +75,7 @@ for (let filePath of testFiles) {
 
         const status = new Promise((resolve) => {
           unsubs.push(
-            api.gearEvents.subscribeProgramEvents((event) => {
+            api.gearEvents.subscribeToProgramEvents((event) => {
               if (event.data.info.programId.toHex() === programs.get(program.id).id) {
                 if (api.events.gear.InitSuccess.is(event)) {
                   resolve('success');
@@ -121,7 +121,7 @@ for (let filePath of testFiles) {
         let messageId, log, unsub;
         if (message.log) {
           log = new Promise((resolve) => {
-            unsub = api.gearEvents.subscribeLogEvents((event) => {
+            unsub = api.gearEvents.subscribeToLogEvents((event) => {
               if (checkLog(event, programs.get(message.program).id, messageId)) {
                 resolve(event.data.payload.toHex());
               }


### PR DESCRIPTION
- Fix tests with new events methods names
- Fix dependencies between files
- Add new type for MessageDispatched event
- Bump version to 0.10.0

@codev0 @EugenWay @aderrod94 @nikitayutanov please keep in mind that when you will change @gear-js/api to version 0.10.0 or upper events subscription will not work without changing methods names