### PR TITLE
Refactor signAndSend method

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -123,8 +123,8 @@ try {
 }
 
 try {
-  await gearApi.program.signAndSend(keyring, (data) => {
-    console.log(data);
+  await gearApi.program.signAndSend(keyring, (event) => {
+    console.log(event.toHuman());
   });
 } catch (error) {
   console.error(`${error.name}: ${error.message}`);
@@ -149,8 +149,8 @@ try {
   console.error(`${error.name}: ${error.message}`);
 }
 try {
-  await gearApi.message.signAndSend(keyring, (data) => {
-    console.log(data);
+  await gearApi.message.signAndSend(keyring, (event) => {
+    console.log(event.toHuman());
   });
 } catch (error) {
   console.error(`${error.name}: ${error.message}`);

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: ['node_modules/(?!@polkadot)/'],
+  verbose: true,
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -48,8 +48,8 @@ export class GearApi extends ApiPromise {
       ...options,
     });
     this.isReady.then(() => {
-      this.program = new GearProgram(this, 'InitMessageEnqueued');
-      this.message = new GearMessage(this, 'DispatchMessageEnqueued');
+      this.program = new GearProgram(this);
+      this.message = new GearMessage(this);
       this.balance = new GearBalance(this);
       this.reply = new GearMessageReply(this);
       this.allEvents = this.query.system.events;

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -36,6 +36,10 @@ export class GearProgram extends GearTransaction {
     }
   }
 
+  /**
+   * Get ids of all uploaded programs
+   * @returns
+   */
   async allUploadedPrograms(): Promise<string[]> {
     let programs = (await this.api.rpc.state.getKeys('g::prog::')).map((prog) => {
       return `0x${prog.toHex().slice(Buffer.from('g::prog::').toString('hex').length + 2)}`;

--- a/api/src/interfaces/transaction.ts
+++ b/api/src/interfaces/transaction.ts
@@ -1,5 +1,8 @@
 import { AddressOrPair, SignerOptions } from '@polkadot/api/types';
+import { Event } from '@polkadot/types/interfaces';
+import { ISubmittableResult } from '@polkadot/types/types';
+// export interface TransactionStatusCb {
+//   (event: Event): void | Promise<void>;
+// }
 
-export interface TransactionStatusCb {
-  (data: any): void | Promise<void>;
-}
+export type TransactionStatusCb = (result: ISubmittableResult, extra: undefined) => void | Promise<void>;

--- a/api/src/interfaces/transaction.ts
+++ b/api/src/interfaces/transaction.ts
@@ -1,8 +1,0 @@
-import { AddressOrPair, SignerOptions } from '@polkadot/api/types';
-import { Event } from '@polkadot/types/interfaces';
-import { ISubmittableResult } from '@polkadot/types/types';
-// export interface TransactionStatusCb {
-//   (event: Event): void | Promise<void>;
-// }
-
-export type TransactionStatusCb = (result: ISubmittableResult, extra: undefined) => void | Promise<void>;

--- a/api/src/interfaces/transaction.ts
+++ b/api/src/interfaces/transaction.ts
@@ -1,0 +1,3 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+
+export type TransactionStatusCb = (result: ISubmittableResult, extra: undefined) => void | Promise<void>;

--- a/api/src/types/Transaction.ts
+++ b/api/src/types/Transaction.ts
@@ -1,85 +1,50 @@
-import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from '@polkadot/api/types';
 import { CreateType } from '../CreateType';
 import { GearApi } from '../GearApi';
 import { TransactionStatusCb } from '../interfaces';
-import { TransactionError } from '../errors';
-import { MessageInfoData } from './EventData';
 import { isFunction } from '@polkadot/util';
+import { AddressOrPair, SignerOptions, SubmittableExtrinsic } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
+import { Hash } from '@polkadot/types/interfaces';
+import { TransactionError } from '../errors';
 
 export class GearTransaction {
   protected api: GearApi;
   protected createType: CreateType;
-  protected method: string;
-  submitted: SubmittableExtrinsic<'promise'>;
+  submitted: SubmittableExtrinsic<'promise', ISubmittableResult>;
 
-  constructor(gearApi: GearApi, method: string) {
+  constructor(gearApi: GearApi) {
     this.api = gearApi;
     this.createType = new CreateType(gearApi);
-    this.method = method;
   }
 
-  signAndSend(account: AddressOrPair, callback: TransactionStatusCb): Promise<0>;
+  signAndSend(account: AddressOrPair, callback: TransactionStatusCb): Promise<() => void>;
 
-  signAndSend(account: AddressOrPair, options: Partial<SignerOptions>): Promise<0>;
+  signAndSend(account: AddressOrPair, options?: Partial<SignerOptions>): Promise<Hash>;
 
-  signAndSend(account: AddressOrPair, options: Partial<SignerOptions>, callback: TransactionStatusCb): Promise<0>;
+  signAndSend(
+    account: AddressOrPair,
+    options: Partial<SignerOptions>,
+    callback: TransactionStatusCb,
+  ): Promise<() => void>;
 
-  public signAndSend(
+  public async signAndSend(
     account: AddressOrPair,
     optionsOrCallback?: Partial<SignerOptions> | TransactionStatusCb,
-    optionalCallback?: (data: any) => void,
-  ): Promise<0> {
+    optionalCallback?: TransactionStatusCb,
+  ): Promise<Hash | (() => void)> {
     const [options, callback] = isFunction(optionsOrCallback)
       ? [undefined, optionsOrCallback]
       : [optionsOrCallback, optionalCallback];
 
-    return new Promise(async (resolve, reject) => {
-      try {
-        let blockHash: string;
-        await this.submitted.signAndSend(account, options, ({ events = [], status }) => {
-          if (status.isInBlock) {
-            blockHash = status.asInBlock.toHex();
-          } else if (status.isFinalized) {
-            blockHash = status.asFinalized.toHex();
-            resolve(0);
-          } else if (status.isInvalid) {
-            reject(new TransactionError(`Transaction error. Status: isInvalid`));
-          }
-
-          // Check transaction errors
-          events
-            .filter(({ event }) => this.api.events.system.ExtrinsicFailed.is(event))
-            .forEach(
-              ({
-                event: {
-                  data: [error],
-                },
-              }) => {
-                reject(new TransactionError(`${error.toString()}`));
-              },
-            );
-
-          events.forEach(({ event: { data, method } }) => {
-            if (method === this.method) {
-              const eventData = new MessageInfoData(data);
-              callback({
-                method,
-                status: status.type,
-                blockHash,
-                programId: eventData.programId.toHex(),
-                messageId: eventData.messageId.toHex(),
-              });
-            }
-          });
-        });
-      } catch (error) {
-        const errorCode = +error.message.split(':')[0];
-        if (errorCode === 1010) {
-          reject(new TransactionError('Account balance too low'));
-        } else {
-          reject(new TransactionError(error.message));
-        }
+    try {
+      return await this.submitted.signAndSend(account, options, callback);
+    } catch (error) {
+      const errorCode = +error.message.split(':')[0];
+      if (errorCode === 1010) {
+        throw new TransactionError('Account balance too low');
+      } else {
+        throw new TransactionError(error.message);
       }
-    });
+    }
   }
 }

--- a/api/test/ProgramsInteract.test.js
+++ b/api/test/ProgramsInteract.test.js
@@ -2,30 +2,24 @@ const { readFileSync, readdirSync } = require('fs');
 const { join } = require('path');
 const yaml = require('js-yaml');
 const { CreateType, GearApi, GearKeyring, getWasmMetadata } = require('../lib');
+const { checkLog, checkInit, sendTransaction } = require('./checkFunctions.js');
 
 const EXAMPLES_DIR = 'test/wasm';
 const programs = new Map();
 const testFiles = readdirSync('test/spec/programs');
 const api = new GearApi();
 const accounts = {
-  alice: GearKeyring.fromSuri('//Alice'),
-  bob: GearKeyring.fromSuri('//Bob'),
+  alice: undefined,
+  bob: undefined,
 };
 const testif = (condition) => (condition ? test : test.skip);
 
-const checkLog = (event, programId, messageId) => {
-  if (event.data.source.toHex() === programId) {
-    if (event.data.reply.unwrap()[1].toNumber() === 0 && event.data.reply.unwrap()[0].toHex() === messageId) {
-      return true;
-    }
-  }
-  return false;
-};
-
-jest.setTimeout(20000);
+jest.setTimeout(15000);
 
 beforeAll(async () => {
   await api.isReady;
+  accounts.alice = await GearKeyring.fromSuri('//Alice');
+  accounts.bob = await GearKeyring.fromSuri('//Bob');
 });
 
 afterAll(async () => {
@@ -73,24 +67,13 @@ for (let filePath of testFiles) {
           });
         }
 
-        const status = new Promise((resolve) => {
-          unsubs.push(
-            api.gearEvents.subscribeToProgramEvents((event) => {
-              if (event.data.info.programId.toHex() === programs.get(program.id).id) {
-                if (api.events.gear.InitSuccess.is(event)) {
-                  resolve('success');
-                } else {
-                  resolve('failed');
-                }
-              }
-            }),
-          );
-        });
-        expect(
-          await api.program.signAndSend(await accounts[program.account], (data) => {
-            messageId = data.messageId;
-          }),
-        ).toBe(0);
+        // Check program initialization
+        const status = checkInit(api, programs.get(program.id).id);
+        const transactionData = await sendTransaction(api.program, accounts[program.account], 'InitMessageEnqueued');
+        messageId = transactionData.messageId;
+
+        expect(transactionData.programId).toBe(programs.get(program.id).id);
+
         expect(await status).toBe('success');
         if (program.log) {
           expect(await log).toBe(program.log);
@@ -128,11 +111,16 @@ for (let filePath of testFiles) {
             });
           });
         }
-        expect(
-          await api.message.signAndSend(await accounts[message.account], (data) => {
-            messageId = data.messageId;
-          }),
-        ).toBe(0);
+
+        const transactionData = await sendTransaction(
+          api.message,
+          accounts[message.account],
+          'DispatchMessageEnqueued',
+        );
+        messageId = transactionData.messageId;
+
+        expect(transactionData).toBeDefined();
+
         if (message.log) {
           expect(await log).toBe(message.log);
           (await unsub)();

--- a/api/test/checkFunctions.js
+++ b/api/test/checkFunctions.js
@@ -1,0 +1,46 @@
+const checkLog = (event, programId, messageId) => {
+  if (event.data[0].source.toHex() === programId) {
+    if (event.data[0].reply.unwrap()[1].toNumber() === 0 && event.data[0].reply.unwrap()[0].toHex() === messageId) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const checkInit = async (api, programId) => {
+  let resolveInit;
+  const initPromise = new Promise((resolve) => {
+    resolveInit = resolve;
+  });
+  const unsub = await api.gearEvents.subscribeToProgramEvents((event) => {
+    if (event.data.info.programId.toHex() === programId) {
+      if (api.events.gear.InitSuccess.is(event)) {
+        resolveInit('success');
+      } else {
+        resolveInit('failed');
+      }
+    }
+  });
+  const result = await initPromise;
+  unsub();
+  return result;
+};
+
+const sendTransaction = async (submitted, account, methodName) => {
+  let transactionResolve;
+  const transactionPromise = new Promise((resolve) => {
+    transactionResolve = resolve;
+  });
+  submitted.signAndSend(account, ({ events = [] }) => {
+    events.forEach(({ event: { method, data } }) => {
+      if (method === 'ExtrinsicFailed') {
+        throw new Error(data.toString());
+      } else if (method === methodName) {
+        transactionResolve(data[0].toHuman());
+      }
+    });
+  });
+  return await transactionPromise;
+};
+
+module.exports = { checkInit, checkLog, sendTransaction };

--- a/api/using-examples/package.json
+++ b/api/using-examples/package.json
@@ -17,7 +17,6 @@
   "license": "ISC",
   "dependencies": {
     "@gear-js/api": "file:../",
-    "@polkadot/api": "^7.4.1",
     "dotenv": "^10.0.0",
     "ts-node": "^10.4.0"
   }

--- a/api/using-examples/src/upload-program.ts
+++ b/api/using-examples/src/upload-program.ts
@@ -1,5 +1,6 @@
 import { GearApi, GearKeyring, getWasmMetadata } from '@gear-js/api';
 import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 export const uploadProgram = async (api: GearApi, pathToProgram: string, pathToMeta?: string, initPayload?: any) => {
   const alice = await GearKeyring.fromSuri('//Alice');
@@ -8,8 +9,17 @@ export const uploadProgram = async (api: GearApi, pathToProgram: string, pathToM
   const meta = metaFile ? await getWasmMetadata(metaFile) : undefined;
 
   const programId = api.program.submit({ code, initPayload, gasLimit: 1_000_000_000 }, meta);
-  await api.program.signAndSend(alice, (data) => {
-    console.log(data);
+  await api.program.signAndSend(alice, ({ events = [], status }) => {
+    console.log(status);
+    events.forEach(({ phase, event: { method, section, data }, topics }) => {
+      console.log(data[0]['messageId'].toHuman());
+    });
   });
   return programId;
 };
+
+const main = async () => {
+  uploadProgram(await GearApi.create(), resolve('test/wasm/demo_ping.opt.wasm'));
+};
+
+main();

--- a/api/using-examples/src/upload-program.ts
+++ b/api/using-examples/src/upload-program.ts
@@ -17,9 +17,3 @@ export const uploadProgram = async (api: GearApi, pathToProgram: string, pathToM
   });
   return programId;
 };
-
-const main = async () => {
-  uploadProgram(await GearApi.create(), resolve('test/wasm/demo_ping.opt.wasm'));
-};
-
-main();


### PR DESCRIPTION
Since `0.11.0` version of @gear-js/api method `signAndSend` will return object of type `Event` like in events subscriptions.

Example how to get messageId with program uploading:
```javascript
api.program.signAndSend(account, ({ events = [], status }) => {
  if (status.isFinalized) {
    console.log(status.asFinalized); // it returns hash of block, where transaction was added
  }
  events.forEach(({ event: { method, section, data } }) => {
      if (method === 'InitMessageDispatched') {
          console.log(data[0]['messageId'].toHuman());
      }
    });
});
```

@aderrod94 @EugenWay @codev0 @nikitayutanov 