### PR TITLE
Get block number

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -254,6 +254,13 @@ const hash = await gearApi.blocks.getBlockHash(blockNumber);
 console.log(hash.toHex());
 ```
 
+### Get block number by blockhash
+
+```javascript
+const hash = await gearApi.blocks.getBlockNumber(blockHash);
+console.log(hash.toNumber());
+```
+
 ### Get all block's events
 
 ```javascript

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/Blocks.ts
+++ b/api/src/Blocks.ts
@@ -1,6 +1,6 @@
 import { GearApi } from './GearApi';
 import { AnyTuple, AnyNumber } from '@polkadot/types/types';
-import { GenericExtrinsic, Vec } from '@polkadot/types';
+import { Compact, GenericExtrinsic, Vec } from '@polkadot/types';
 import { SignedBlock, BlockNumber, BlockHash } from '@polkadot/types/interfaces';
 import { FrameSystemEventRecord } from '@polkadot/types/lookup';
 import { GetBlockError } from './errors/blocks.errors';
@@ -31,6 +31,16 @@ export class GearBlock {
    */
   async getBlockHash(number: AnyNumber | BlockNumber): Promise<BlockHash> {
     return await this.api.rpc.chain.getBlockHash(number);
+  }
+
+  /**
+   * Get block number
+   * @param hash
+   * @returns Compact<BlockNumber>
+   */
+  async getBlockNumber(hash: `0x${string}` | Uint8Array): Promise<Compact<BlockNumber>> {
+    const block = await this.get(hash);
+    return block.block.header.number;
   }
 
   /**

--- a/api/test/GearApi.test.js
+++ b/api/test/GearApi.test.js
@@ -49,4 +49,10 @@ describe('Blocks', () => {
   test('get finalized head', async () => {
     expect(await api.blocks.getFinalizedHead()).toBeDefined();
   });
+
+  test('get block number by hash', async () => {
+    const hash = await api.blocks.getBlockHash(1);
+    const blockNumber = await api.blocks.getBlockNumber(hash.toHex());
+    expect(blockNumber.toNumber()).toBe(1);
+  });
 });


### PR DESCRIPTION
- Add method to get block number by hash
- Bump version to `0.11.2`
```javascript
const hash = await gearApi.blocks.getBlockNumber(blockHash);
console.log(hash.toNumber());
```