### PR TITLE
make `blockHash` of `IBaseDBRecord` optional

### DIFF
--- a/website/interfaces/src/general.ts
+++ b/website/interfaces/src/general.ts
@@ -3,8 +3,8 @@ export interface IGenesis {
 }
 
 export interface IBaseDBRecord<Timestamp extends Date | number> extends IGenesis {
-  blockHash: string;
-  timestamp: Timestamp;
+  blockHash?: string;
+  timestamp?: Timestamp;
 }
 
 export interface ISignature {


### PR DESCRIPTION
Some fields of `IBaseDBRecord` are actually nullable, judging by the schema. This PR addresses that discrepancy.

This PR is a prerequisite to #318.
