### PR TITLE
Fix eslint file extension error

### DIFF
--- a/website/frontend/.eslintrc
+++ b/website/frontend/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["airbnb-typescript", "airbnb/hooks", "prettier"],
-  "plugins": ["import"],
+  "plugins": ["react", "import"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json"
@@ -36,7 +36,8 @@
     "react/prop-types": "off",
     "react/destructuring-assignment": ["off"],
     "no-underscore-dangle": "off",
-    "@typescript-eslint/no-unused-vars": ["warn"]
+    "@typescript-eslint/no-unused-vars": ["warn"],
+    "@typescript-eslint/no-redeclare": "off"
   },
   "settings": {
     "react": {

--- a/website/frontend/package.json
+++ b/website/frontend/package.json
@@ -53,18 +53,6 @@
     "lint:fix": "eslint ./src --fix --color",
     "format": "prettier --write src/"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "src/**/*.{ts,tsx,json}": [
-      "eslint --fix src/",
-      "prettier --write",
-      "git add"
-    ]
-  },
   "eslintConfig": {
     "extends": [
       "react-app",
@@ -111,8 +99,6 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.2",
     "eslint-plugin-react-hooks": "4.3.0",
-    "husky": "7.0.4",
-    "lint-staged": "12.3.4",
     "prettier": "2.5.1",
     "sass": "1.49.9",
     "stream-browserify": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11944,29 +11944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:12.3.4":
-  version: 12.3.4
-  resolution: "lint-staged@npm:12.3.4"
-  dependencies:
-    cli-truncate: ^3.1.0
-    colorette: ^2.0.16
-    commander: ^8.3.0
-    debug: ^4.3.3
-    execa: ^5.1.1
-    lilconfig: 2.0.4
-    listr2: ^4.0.1
-    micromatch: ^4.0.4
-    normalize-path: ^3.0.0
-    object-inspect: ^1.12.0
-    string-argv: ^0.3.1
-    supports-color: ^9.2.1
-    yaml: ^1.10.2
-  bin:
-    lint-staged: bin/lint-staged.js
-  checksum: 4e0b4b9da4183a0daeab35d41e4d243fb1270a39db997efa0c3745fa148a7a4b8b723a51cb757595fc8bb118796ca1465e67aede72f25e9ea48165aec36cec3b
-  languageName: node
-  linkType: hard
-
 "lint-staged@npm:12.3.5":
   version: 12.3.5
   resolution: "lint-staged@npm:12.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,10 +1988,8 @@ __metadata:
     eslint-plugin-react-hooks: 4.3.0
     file-saver: 2.0.5
     formik: 2.2.9
-    husky: 7.0.4
     jszip: 3.7.1
     ky: 0.29.0
-    lint-staged: 12.3.4
     localforage: 1.10.0
     lodash.get: 4.4.2
     lodash.isobject: 3.0.2


### PR DESCRIPTION
- Drop husky and lint-staged deps
- Fix eslint `Definition for rule 'react/jsx-filename-extension' was not found` error