### PR TITLE
Fix create payload structure

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "7.16.11",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/create-type/generate.ts
+++ b/api/src/create-type/generate.ts
@@ -1,7 +1,8 @@
+import { isJSON, toJSON } from '../utils';
 import { Types, TypeTree } from './interfaces';
 
 const getTree = (type: Types, name: string, value: string | object | TypeTree, count?: number): TypeTree => {
-  const tree = { type, name, value };
+  const tree = { type, name, value: isJSON(value) ? toJSON(value) : value };
   return type === 'Array' ? { ...tree, count } : tree;
 };
 

--- a/api/src/create-type/payload-type-structure.ts
+++ b/api/src/create-type/payload-type-structure.ts
@@ -1,5 +1,5 @@
 import { enumTypes, TypeTree } from './interfaces';
-import { splitByCommas } from '../utils';
+import { isJSON, splitByCommas, toJSON } from '../utils';
 import generate from './generate';
 import { REGULAR_EXP } from './regexp';
 
@@ -45,14 +45,20 @@ function getIfGeneric(typeName: string, types: any): TypeTree | null {
 }
 
 function getIfStruct(typeName: string, types: any): TypeTree | null {
+  const value: any = {};
   if (types[typeName] && typeof types[typeName] === 'object') {
-    const value: any = {};
     Object.keys(types[typeName]).forEach((field) => {
       value[field] = createPayloadTypeStructure(types[typeName][field], types);
     });
-    return generate.Struct(typeName, value);
+  } else if (isJSON(typeName)) {
+    const jsonTypeName = toJSON(typeName);
+    Object.keys(jsonTypeName).forEach((field) => {
+      value[field] = createPayloadTypeStructure(jsonTypeName[field], types);
+    });
+  } else {
+    return null;
   }
-  return null;
+  return generate.Struct(typeName, value);
 }
 
 function getIfEnum(typeName: string, types: any): TypeTree | null {

--- a/api/src/create-type/payload-type-structure.ts
+++ b/api/src/create-type/payload-type-structure.ts
@@ -24,7 +24,7 @@ function getIfArray(typeName: string, types: any, raw: boolean): TypeTree | [Typ
   return null;
 }
 
-function getIfGeneric(typeName: string, types: any, raw: boolean): TypeTree | null {
+function getIfGeneric(typeName: string, types: any, raw: boolean): TypeTree | any | null {
   const match = typeName.match(REGULAR_EXP.angleBracket);
   if (match) {
     const type = typeName.slice(0, match.index);
@@ -35,7 +35,19 @@ function getIfGeneric(typeName: string, types: any, raw: boolean): TypeTree | nu
         createPayloadTypeStructure(splitted[0], types, raw),
         createPayloadTypeStructure(splitted[1], types, raw),
       ];
-      return raw ? { [`_${type}`]: value } : generate[type](typeName, ...value);
+      if (raw) {
+        if (type === 'Result') {
+          return {
+            _Result: {
+              ok: value[0],
+              err: value[1],
+            },
+          };
+        } else {
+          return { [`_${type}`]: value[1] ? value : value[0] };
+        }
+      }
+      return generate[type](typeName, ...value);
     } else {
       return createPayloadTypeStructure(type, types, raw);
     }
@@ -78,6 +90,7 @@ function getIfEnum(typeName: string, types: any, raw: boolean): TypeTree | { _en
  *
  * @param typeName to create its structure
  * @param types
+ * @param raw set it to true if there is a need to get type structure without additional fields
  * @returns
  */
 export function createPayloadTypeStructure(typeName: string, types: any, raw = false): TypeTree | any {

--- a/api/src/create-type/payload-type-structure.ts
+++ b/api/src/create-type/payload-type-structure.ts
@@ -3,73 +3,72 @@ import { isJSON, splitByCommas, toJSON } from '../utils';
 import generate from './generate';
 import { REGULAR_EXP } from './regexp';
 
-function getIfTuple(typeName: string, types: any): TypeTree | null {
+function getIfTuple(typeName: string, types: any, raw: boolean): TypeTree | TypeTree[] | null {
   const match = typeName.match(REGULAR_EXP.roundBracket);
   if (match) {
     const entryType = match[0].slice(1, match[0].length - 1);
     const splitted = splitByCommas(entryType);
-    return generate.Tuple(
-      typeName,
-      splitted.map((value) => createPayloadTypeStructure(value, types)),
-    );
+    const value = splitted.map((value) => createPayloadTypeStructure(value, types, raw));
+    return raw ? value : generate.Tuple(typeName, value);
   }
   return null;
 }
 
-function getIfArray(typeName: string, types: any): TypeTree | null {
+function getIfArray(typeName: string, types: any, raw: boolean): TypeTree | [TypeTree, number] | null {
   const match = typeName.match(REGULAR_EXP.squareBracket);
   if (match) {
     const splitted = typeName.slice(1, typeName.length - 1).split(';');
-    return generate.Array(typeName, createPayloadTypeStructure(splitted[0], types), parseInt(splitted[1]));
+    const value: [TypeTree, number] = [createPayloadTypeStructure(splitted[0], types, raw), parseInt(splitted[1])];
+    return raw ? value : generate.Array(typeName, ...value);
   }
   return null;
 }
 
-function getIfGeneric(typeName: string, types: any): TypeTree | null {
+function getIfGeneric(typeName: string, types: any, raw: boolean): TypeTree | null {
   const match = typeName.match(REGULAR_EXP.angleBracket);
   if (match) {
     const type = typeName.slice(0, match.index);
     if (type in enumTypes) {
       const entryType = match[0].slice(1, match[0].length - 1);
       const splitted = splitByCommas(entryType);
-      return generate[type](
-        typeName,
-        createPayloadTypeStructure(splitted[0], types),
-        createPayloadTypeStructure(splitted[1], types),
-      );
+      const value = [
+        createPayloadTypeStructure(splitted[0], types, raw),
+        createPayloadTypeStructure(splitted[1], types, raw),
+      ];
+      return raw ? { [`_${type}`]: value } : generate[type](typeName, ...value);
     } else {
-      return createPayloadTypeStructure(type, types);
+      return createPayloadTypeStructure(type, types, raw);
     }
   }
   return null;
 }
 
-function getIfStruct(typeName: string, types: any): TypeTree | null {
+function getIfStruct(typeName: string, types: any, raw: boolean): TypeTree | null {
   const value: any = {};
   if (types[typeName] && typeof types[typeName] === 'object') {
     Object.keys(types[typeName]).forEach((field) => {
-      value[field] = createPayloadTypeStructure(types[typeName][field], types);
+      value[field] = createPayloadTypeStructure(types[typeName][field], types, raw);
     });
   } else if (isJSON(typeName)) {
     const jsonTypeName = toJSON(typeName);
     Object.keys(jsonTypeName).forEach((field) => {
-      value[field] = createPayloadTypeStructure(jsonTypeName[field], types);
+      value[field] = createPayloadTypeStructure(jsonTypeName[field], types, raw);
     });
   } else {
     return null;
   }
-  return generate.Struct(typeName, value);
+  return raw ? value : generate.Struct(typeName, value);
 }
 
-function getIfEnum(typeName: string, types: any): TypeTree | null {
+function getIfEnum(typeName: string, types: any, raw: boolean): TypeTree | { _enum: any } | null {
   if (types[typeName] && typeof types[typeName] === 'object') {
     if (Object.keys(types[typeName]).length === 1 && Object.keys(types[typeName]).includes('_enum')) {
       const type = types[typeName];
       const value: any = {};
       Object.keys(type['_enum']).forEach((field) => {
-        value[field] = createPayloadTypeStructure(type['_enum'][field], types);
+        value[field] = createPayloadTypeStructure(type['_enum'][field], types, raw);
       });
-      return generate.Enum(typeName, value);
+      return raw ? { _enum: value } : generate.Enum(typeName, value);
     }
   }
   return null;
@@ -81,34 +80,34 @@ function getIfEnum(typeName: string, types: any): TypeTree | null {
  * @param types
  * @returns
  */
-export function createPayloadTypeStructure(typeName: string, types: any): TypeTree {
+export function createPayloadTypeStructure(typeName: string, types: any, raw = false): TypeTree | any {
   if (!typeName) {
     return undefined;
   }
-  const tuple = getIfTuple(typeName, types);
+  const tuple = getIfTuple(typeName, types, raw);
   if (tuple) {
     return tuple;
   }
 
-  const array = getIfArray(typeName, types);
+  const array = getIfArray(typeName, types, raw);
   if (array) {
     return array;
   }
 
-  const generic = getIfGeneric(typeName, types);
+  const generic = getIfGeneric(typeName, types, raw);
   if (generic) {
     return generic;
   }
 
-  const _enum = getIfEnum(typeName, types);
+  const _enum = getIfEnum(typeName, types, raw);
   if (_enum) {
     return _enum;
   }
 
-  const struct = getIfStruct(typeName, types);
+  const struct = getIfStruct(typeName, types, raw);
   if (struct) {
     return struct;
   }
 
-  return generate.Primitive(typeName);
+  return raw ? typeName : generate.Primitive(typeName);
 }

--- a/api/src/create-type/utils.ts
+++ b/api/src/create-type/utils.ts
@@ -23,9 +23,9 @@ export function setNamespaces(type: string, namespaces: Map<string, string>): st
   matches.forEach((match, index) => {
     if (namespaces) {
       if (namespaces.has(match)) {
-        type = type.replace(match, namespaces.get(match));
+        type = type.replace(new RegExp(match, 'g'), namespaces.get(match));
       } else if (index < matches.length - 1 && namespaces.has(`${match}${matches[index + 1]}`)) {
-        type = type.replace(match, namespaces.get(`${match}${matches[index + 1]}`));
+        type = type.replace(new RegExp(match, 'g'), namespaces.get(`${match}${matches[index + 1]}`));
       }
     }
   });
@@ -35,7 +35,7 @@ export function setNamespaces(type: string, namespaces: Map<string, string>): st
 export function replaceNamespaces(type: string, namespaces: Map<string, string>): string {
   const match = type.match(REGULAR_EXP.endWord);
   namespaces.forEach((value, key) => {
-    type = match.includes(value) ? type.replace(value, key) : type;
+    type = match.includes(value) ? type.replace(new RegExp(value, 'g'), key) : type;
   });
   return type;
 }

--- a/api/test/CreateTypeStructure.test.js
+++ b/api/test/CreateTypeStructure.test.js
@@ -14,6 +14,16 @@ describe('Create type structure test', () => {
       AStruct: { id: 'Bytes', online: 'bool' },
       CustomStructU8: { field: 'u8' },
       CustomStructOption: { field: 'Option<(Option<u8>,u128,[u8;3])>' },
+      FungibleTokenAction: {
+        _enum: {
+          Mint: 'u128',
+          Burn: 'u128',
+          Transfer: '{"from":"ActorId","to":"ActorId","amount":"u128"}',
+          Approve: '{"to":"ActorId","amount":"u128"}',
+          TotalSupply: 'Null',
+          BalanceOf: 'ActorId',
+        },
+      },
     };
   });
   test('Enum', () => {
@@ -203,6 +213,39 @@ describe('Create type structure test', () => {
         type: 'Primitive',
         name: 'u8',
         value: 'u8',
+      },
+    });
+  });
+  test('FungibleTokenAction', () => {
+    expect(createPayloadTypeStructure('FungibleTokenAction', types)).toEqual({
+      type: 'Enum',
+      name: 'FungibleTokenAction',
+      value: {
+        Mint: { type: 'Primitive', name: 'u128', value: 'u128' },
+        Burn: { type: 'Primitive', name: 'u128', value: 'u128' },
+        Transfer: {
+          type: 'Struct',
+          name: '{"from":"ActorId","to":"ActorId","amount":"u128"}',
+          value: {
+            from: { type: 'Primitive', name: 'ActorId', value: 'ActorId' },
+            to: { type: 'Primitive', name: 'ActorId', value: 'ActorId' },
+            amount: { type: 'Primitive', name: 'u128', value: 'u128' },
+          },
+        },
+        Approve: {
+          type: 'Struct',
+          name: '{"to":"ActorId","amount":"u128"}',
+          value: {
+            to: { type: 'Primitive', name: 'ActorId', value: 'ActorId' },
+            amount: { type: 'Primitive', name: 'u128', value: 'u128' },
+          },
+        },
+        TotalSupply: { type: 'Primitive', name: 'Null', value: 'Null' },
+        BalanceOf: {
+          type: 'Primitive',
+          name: 'ActorId',
+          value: 'ActorId',
+        },
       },
     });
   });

--- a/api/test/CreateTypeStructure.test.js
+++ b/api/test/CreateTypeStructure.test.js
@@ -131,6 +131,14 @@ describe('Create type structure test', () => {
       },
     });
   });
+  test('Raw Result', () => {
+    expect(createPayloadTypeStructure('Result<String, i32>', {}, true)).toEqual({
+      _Result: {
+        ok: 'String',
+        err: 'i32',
+      },
+    });
+  });
   test('Primitive', () => {
     expect(createPayloadTypeStructure('String', {})).toEqual({
       type: 'Primitive',
@@ -161,6 +169,9 @@ describe('Create type structure test', () => {
       ],
     });
   });
+  test('Raw Tuple', () => {
+    expect(createPayloadTypeStructure('(String, u8)', types, true)).toEqual(['String', 'u8']);
+  });
   test('Array', () => {
     expect(createPayloadTypeStructure('[u8;4]', types)).toEqual({
       type: 'Array',
@@ -173,6 +184,9 @@ describe('Create type structure test', () => {
       count: 4,
     });
   });
+  test('Raw Array', () => {
+    expect(createPayloadTypeStructure('[u8;4]', types, true)).toEqual(['u8', 4]);
+  });
   test('Option', () => {
     expect(createPayloadTypeStructure('Option<AStruct>', types)).toEqual({
       type: 'Option',
@@ -184,6 +198,14 @@ describe('Create type structure test', () => {
           id: { type: 'Primitive', name: 'Bytes', value: 'Bytes' },
           online: { type: 'Primitive', name: 'bool', value: 'bool' },
         },
+      },
+    });
+  });
+  test('Raw Option', () => {
+    expect(createPayloadTypeStructure('Option<AStruct>', types, true)).toEqual({
+      _Option: {
+        id: 'Bytes',
+        online: 'bool',
       },
     });
   });
@@ -205,6 +227,11 @@ describe('Create type structure test', () => {
       },
     });
   });
+  test('Raw BTreeMap', () => {
+    expect(createPayloadTypeStructure('BTreeMap<String, u8>', types, true)).toEqual({
+      _BTreeMap: ['String', 'u8'],
+    });
+  });
   test('BTreeSet', () => {
     expect(createPayloadTypeStructure('BTreeSet<u8>', types)).toEqual({
       type: 'BTreeSet',
@@ -214,6 +241,11 @@ describe('Create type structure test', () => {
         name: 'u8',
         value: 'u8',
       },
+    });
+  });
+  test('Raw BTreeSet', () => {
+    expect(createPayloadTypeStructure('BTreeSet<u8>', types, true)).toEqual({
+      _BTreeSet: 'u8',
     });
   });
   test('FungibleTokenAction', () => {
@@ -246,6 +278,18 @@ describe('Create type structure test', () => {
           name: 'ActorId',
           value: 'ActorId',
         },
+      },
+    });
+  });
+  test('Raw FungibleTokenAction', () => {
+    expect(createPayloadTypeStructure('FungibleTokenAction', types, true)).toEqual({
+      _enum: {
+        Mint: 'u128',
+        Burn: 'u128',
+        Transfer: { from: 'ActorId', to: 'ActorId', amount: 'u128' },
+        Approve: { to: 'ActorId', amount: 'u128' },
+        TotalSupply: 'Null',
+        BalanceOf: 'ActorId',
       },
     });
   });


### PR DESCRIPTION
### Fix: 
- Replace all namespaces instead only one
- Check `Struct` types
 ### Add:
- Argument `raw` in `createPayloadTypeStructure` function. 
If it is specified payload structure will  be created without additional fields (type, name, value)
<hr>

## Bump version to 0.14.4