### PR TITLE
Remove deprecated functions for the payload type structure

### DIFF
--- a/website/frontend/package.json
+++ b/website/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "private": true,
   "dependencies": {
-    "@gear-js/api": "0.14.3",
+    "@gear-js/api": "0.14.4",
     "@monaco-editor/react": "4.3.1",
     "@polkadot/api": "7.10.1",
     "@polkadot/extension-dapp": "0.42.7",

--- a/website/frontend/src/components/pages/Program/children/MetaData/MetaData.tsx
+++ b/website/frontend/src/components/pages/Program/children/MetaData/MetaData.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Metadata, getTypeStructure, parseHexTypes } from '@gear-js/api';
+import { Metadata, createPayloadTypeStructure, decodeHexTypes } from '@gear-js/api';
 import { MetaField } from './children/MetaField/MetaField';
 import styles from './MetaData.module.scss';
 
@@ -12,12 +12,12 @@ export const MetaData: FC<Props> = ({ metadata }) => {
     let items = [];
 
     if (metadata && metadata.types) {
-      const types = parseHexTypes(metadata.types);
+      const decodedTypes = decodeHexTypes(metadata.types);
       let key: keyof typeof metadata;
 
       for (key in metadata) {
         if (metadata[key] && key !== 'types' && key !== 'title') {
-          const type = getTypeStructure(metadata[key] as string, types);
+          const type = createPayloadTypeStructure(metadata[key] as string, decodedTypes, true);
 
           items.push({
             label: key,

--- a/website/frontend/src/components/pages/Programs/children/Upload/children/UploadForm/UploadForm.tsx
+++ b/website/frontend/src/components/pages/Programs/children/Upload/children/UploadForm/UploadForm.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import clsx from 'clsx';
 import { Trash2 } from 'react-feather';
 import NumberFormat from 'react-number-format';
-import { Metadata, getWasmMetadata, parseHexTypes, getTypeStructure } from '@gear-js/api';
+import { Metadata, getWasmMetadata, createPayloadTypeStructure, decodeHexTypes } from '@gear-js/api';
 import { Formik, Form, Field } from 'formik';
 import { ParsedShape, parseMeta } from 'utils/meta-parser';
 import { InitialValues } from './types';
@@ -62,8 +62,8 @@ export const UploadForm: VFC<Props> = ({ setDroppedFile, droppedFile }) => {
 
       if (metaWasm) {
         const bufstr = Buffer.from(new Uint8Array(fileBuffer)).toString('base64');
-        const types = parseHexTypes(metaWasm?.types);
-        const typeStructure = getTypeStructure(metaWasm?.init_input, types);
+        const decodedTypes = decodeHexTypes(metaWasm?.types);
+        const typeStructure = createPayloadTypeStructure(metaWasm?.init_input, decodedTypes, true);
         const parsedStructure = parseMeta(typeStructure);
 
         let valuesFromFile = {};
@@ -79,7 +79,7 @@ export const UploadForm: VFC<Props> = ({ setDroppedFile, droppedFile }) => {
 
         valuesFromFile = {
           ...valuesFromFile,
-          types: getPreformattedText(types),
+          types: getPreformattedText(decodedTypes),
         };
 
         setMeta(metaWasm);

--- a/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
+++ b/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState, VFC } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-import { createPayloadTypeStructure, Metadata, decodeHexTypes } from '@gear-js/api';
+import { Metadata, createPayloadTypeStructure, decodeHexTypes } from '@gear-js/api';
 import { MetaParam } from 'utils/meta-parser';
 import { RPC_METHODS } from 'consts';
 import ServerRPCRequestService, { RPCResponseError } from 'services/ServerRPCRequestService';

--- a/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
+++ b/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
@@ -44,10 +44,10 @@ export const SendMessage: VFC = () => {
 
   useEffect(() => {
     if (meta && meta.types && meta.handle_input) {
-      const displayedTypes = decodeHexTypes(meta.types);
-      const inputType = createPayloadTypeStructure(meta.handle_input, displayedTypes, true);
+      const decodedTypes = decodeHexTypes(meta.types);
+      const typeStructure = createPayloadTypeStructure(meta.handle_input, decodedTypes, true);
 
-      setTypes(inputType);
+      setTypes(typeStructure);
     }
   }, [meta, setTypes]);
 

--- a/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
+++ b/website/frontend/src/components/pages/SendMessage/SendMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState, VFC } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-import { getTypeStructure, Metadata, parseHexTypes } from '@gear-js/api';
+import { createPayloadTypeStructure, Metadata, decodeHexTypes } from '@gear-js/api';
 import { MetaParam } from 'utils/meta-parser';
 import { RPC_METHODS } from 'consts';
 import ServerRPCRequestService, { RPCResponseError } from 'services/ServerRPCRequestService';
@@ -44,8 +44,8 @@ export const SendMessage: VFC = () => {
 
   useEffect(() => {
     if (meta && meta.types && meta.handle_input) {
-      const displayedTypes = parseHexTypes(meta.types);
-      const inputType = getTypeStructure(meta.handle_input, displayedTypes);
+      const displayedTypes = decodeHexTypes(meta.types);
+      const inputType = createPayloadTypeStructure(meta.handle_input, displayedTypes, true);
 
       setTypes(inputType);
     }

--- a/website/frontend/src/components/pages/State/State.tsx
+++ b/website/frontend/src/components/pages/State/State.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState, VFC } from 'react';
 import clsx from 'clsx';
 import { ParsedShape, parseMeta } from 'utils/meta-parser';
-import { getTypeStructure, getWasmMetadata, Metadata, parseHexTypes } from '@gear-js/api';
+import { Metadata, getWasmMetadata, createPayloadTypeStructure, decodeHexTypes } from '@gear-js/api';
 import { Formik, Form } from 'formik';
 import { Spinner } from 'components/blocks/Spinner/Spinner';
 import BackArrow from 'assets/images/arrow_back_thick.svg';
@@ -68,8 +68,8 @@ const State: VFC = () => {
 
   const getPayloadForm = useCallback(() => {
     if (stateInput && types) {
-      const parsedTypes = parseHexTypes(types);
-      const typeStruct = getTypeStructure(stateInput, parsedTypes);
+      const decodedTypes = decodeHexTypes(types);
+      const typeStruct = createPayloadTypeStructure(stateInput, decodedTypes, true);
       const parsedStruct = parseMeta(typeStruct);
       setTypeStructure(typeStruct);
       setForm(parsedStruct);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,7 +1877,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-
 "@gear-js/api@npm:0.14.4":
   version: 0.14.4
   resolution: "@gear-js/api@npm:0.14.4"
@@ -1888,23 +1887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gear-js/api@npm:^0.14.2, @gear-js/api@npm:^0.14.3":
+"@gear-js/api@npm:^0.14.2":
   version: 0.14.3
   resolution: "@gear-js/api@npm:0.14.3"
   peerDependencies:
     "@polkadot/api": ^7.10.1
     rxjs: ^7.3.0
   checksum: b42737067c472e98373f8fa3462fe7e05daff9457a72de87793330785b0280438a8306ac41fbd88e9dfb05f6dabb63f40310e33369b1da74508f0968ece9aa6b
-  languageName: node
-  linkType: hard
-
-"@gear-js/api@npm:0.14.4":
-  version: 0.14.4
-  resolution: "@gear-js/api@npm:0.14.4"
-  peerDependencies:
-    "@polkadot/api": ^7.10.1
-    rxjs: ^7.3.0
-  checksum: c331f4aa1ffe39bae79df38074adc3e8b20ee8ecffd1a7ee5e9c408fb245de457f43d2afe729202022c90b8bf676ac7e5ae4669381f71a3020da73cd38493002
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,7 +1877,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gear-js/api@npm:0.14.3, @gear-js/api@npm:^0.14.2, @gear-js/api@npm:^0.14.3":
+"@gear-js/api@npm:0.14.4":
+  version: 0.14.4
+  resolution: "@gear-js/api@npm:0.14.4"
+  peerDependencies:
+    "@polkadot/api": ^7.10.1
+    rxjs: ^7.3.0
+  checksum: c331f4aa1ffe39bae79df38074adc3e8b20ee8ecffd1a7ee5e9c408fb245de457f43d2afe729202022c90b8bf676ac7e5ae4669381f71a3020da73cd38493002
+  languageName: node
+  linkType: hard
+
+"@gear-js/api@npm:^0.14.2, @gear-js/api@npm:^0.14.3":
   version: 0.14.3
   resolution: "@gear-js/api@npm:0.14.3"
   peerDependencies:
@@ -1963,7 +1973,7 @@ __metadata:
   resolution: "@gear-js/frontend@workspace:website/frontend"
   dependencies:
     "@craco/craco": 6.4.3
-    "@gear-js/api": 0.14.3
+    "@gear-js/api": 0.14.4
     "@monaco-editor/react": 4.3.1
     "@polkadot/api": 7.10.1
     "@polkadot/extension-dapp": 0.42.7


### PR DESCRIPTION
- Bump api to 0.14.4
- Change deprecated functions
