### PR TITLE
Fix custom type registration

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "7.16.11",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -31,7 +31,7 @@ export class GearApi extends ApiPromise {
 
   constructor(options?: GearApiOptions) {
     const { types, providerAddress, ...restOptions } = options;
-    const provider = remain?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
+    const provider = restOptions?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
     const defaultTypes = types ? { ...types, ...gearTypes } : gearTypes;
 
     super({
@@ -43,7 +43,7 @@ export class GearApi extends ApiPromise {
       rpc: {
         ...gearRpc,
       },
-      ...remain,
+      ...restOptions,
     });
 
     this.isReady.then(() => {

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -29,7 +29,7 @@ export class GearApi extends ApiPromise {
   public claimValueFromMailbox: GearClaimValue;
   public code: GearCode;
 
-  constructor(options?: GearApiOptions) {
+  constructor(options: GearApiOptions = {}) {
     const { types, providerAddress, ...restOptions } = options;
     const provider = restOptions?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
     const defaultTypes = types ? { ...types, ...gearTypes } : gearTypes;

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -30,7 +30,7 @@ export class GearApi extends ApiPromise {
   public code: GearCode;
 
   constructor(options?: GearApiOptions) {
-    const { types, providerAddress, ...remain } = options;
+    const { types, providerAddress, ...restOptions } = options;
     const provider = remain?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
     const defaultTypes = types ? { ...types, ...gearTypes } : gearTypes;
 

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -32,10 +32,7 @@ export class GearApi extends ApiPromise {
   constructor(options?: GearApiOptions) {
     const { types, providerAddress, ...remain } = options;
     const provider = remain?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
-    const defaultTypes = {
-      ...(types || {}),
-      ...gearTypes,
-    };
+    const defaultTypes = types ? { ...types, ...gearTypes } : gearTypes;
 
     super({
       provider,

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -4,14 +4,10 @@ import { GearBalance } from './Balance';
 import { GearEvents } from './Events';
 import { GearProgramState } from './State';
 import { GearMessageReply } from './MessageReply';
-import { transformTypes } from './utils';
 import { gearRpc, gearTypes } from './default';
 import { GearApiOptions } from './interfaces';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { EventRecord, ContractExecResultErr, Event } from '@polkadot/types/interfaces';
-import { PromiseResult } from '@polkadot/api/types';
-import { Vec } from '@polkadot/types';
-import { Observable } from 'rxjs';
+import { ContractExecResultErr, Event } from '@polkadot/types/interfaces';
 import { GearBlock } from './Blocks';
 import { GearStorage } from './Storage';
 import { GearMailbox } from './Mailbox';
@@ -25,7 +21,6 @@ export class GearApi extends ApiPromise {
   public message: GearMessage;
   public reply: GearMessageReply;
   public balance: GearBalance;
-  public allEvents: PromiseResult<() => Observable<Vec<EventRecord>>>;
   public gearEvents: GearEvents;
   public defaultTypes: any;
   public blocks: GearBlock;
@@ -35,18 +30,13 @@ export class GearApi extends ApiPromise {
   public code: GearCode;
 
   constructor(options?: GearApiOptions) {
-    const provider = options?.provider
-      ? options.provider
-      : new WsProvider(options?.providerAddress ?? 'ws://127.0.0.1:9944');
+    const { types, providerAddress, ...remain } = options;
+    const provider = remain?.provider || new WsProvider(providerAddress ?? 'ws://127.0.0.1:9944');
+    const defaultTypes = {
+      ...(types || {}),
+      ...gearTypes,
+    };
 
-    const defaultTypes = options?.customTypes
-      ? {
-          ...gearTypes,
-          ...transformTypes(
-            'types' in options.customTypes ? options.customTypes : { types: { ...options.customTypes } },
-          ),
-        }
-      : gearTypes;
     super({
       provider,
       derives: {},
@@ -56,14 +46,14 @@ export class GearApi extends ApiPromise {
       rpc: {
         ...gearRpc,
       },
-      ...options,
+      ...remain,
     });
+
     this.isReady.then(() => {
       this.program = new GearProgram(this);
       this.message = new GearMessage(this);
       this.balance = new GearBalance(this);
       this.reply = new GearMessageReply(this);
-      this.allEvents = this.query.system.events;
       this.gearEvents = new GearEvents(this);
       this.defaultTypes = defaultTypes;
       this.programState = new GearProgramState(this);

--- a/api/src/State.ts
+++ b/api/src/State.ts
@@ -8,8 +8,8 @@ import { GearStorage } from './Storage';
 export class GearProgramState extends GearStorage {
   /**
    * Decode state to meta_state_output type
-   * @param metaWasm - file with metadata
-   * @param pages - pages with program state
+   * @param state - Uint8Array state representation
+   * @param meta - Metadata
    * @returns decoded state
    */
   decodeState(state: Uint8Array, meta: Metadata): Codec {
@@ -17,18 +17,18 @@ export class GearProgramState extends GearStorage {
       throw new ReadStateError(`Unable to read state. meta_state function is not specified in metadata`);
     }
     const bytes = this.api.createType('Bytes', Array.from(state));
-    const decoded = CreateType.create(meta.meta_state_output, bytes, meta);
+    const decoded = this.createType.create(meta.meta_state_output, bytes, meta);
     return decoded;
   }
 
   /**
    * Encode input parameters to read meta state
-   * @param metaWasm - file with metadata
+   * @param meta - Metadata
    * @param inputValue - input parameters
    * @returns ArrayBuffer with encoded data
    */
   encodeInput(meta: Metadata, inputValue: any): Uint8Array {
-    const encoded = CreateType.create(meta.meta_state_input, inputValue, meta);
+    const encoded = this.createType.create(meta.meta_state_input, inputValue, meta);
     return encoded.toU8a();
   }
 

--- a/api/src/Storage.ts
+++ b/api/src/Storage.ts
@@ -3,6 +3,7 @@ import { Hex, IActiveProgram, IGearPages, IProgram, ProgramId } from './interfac
 import { u32, Option, Raw } from '@polkadot/types';
 import { Codec } from '@polkadot/types/types';
 import { u8aToHex } from '@polkadot/util';
+import { CreateType } from './create-type';
 
 const PREFIXES = {
   prog: Buffer.from('g::prog::').toString('hex'),
@@ -13,9 +14,11 @@ const SEPARATOR = Buffer.from('::').toString('hex');
 
 export class GearStorage {
   api: GearApi;
+  createType: CreateType;
 
   constructor(api: GearApi) {
     this.api = api;
+    this.createType = new CreateType(api);
   }
   /**
    * Get program from chain

--- a/api/src/interfaces/gear-api.ts
+++ b/api/src/interfaces/gear-api.ts
@@ -5,7 +5,6 @@ import { ApiOptions } from '@polkadot/api/types';
 import { AccountId32 } from '@polkadot/types/interfaces';
 export interface GearApiOptions extends ApiOptions {
   providerAddress?: string;
-  customTypes?: GearType;
 }
 
 export interface ExitCode extends i32 {}


### PR DESCRIPTION
### Fix: 
- Remove `customType` parameter from `GearApiOption` and replace it with `types` 

### Remove:
- `allEvents` variable from `GearApi` class. You can use `gearApi.query.system.events` instead
<hr>

## Bump @gear-js/api to 0.15.2