### PR TITLE
Add styles export

### DIFF
--- a/utils/gear-ui/package-lock.json
+++ b/utils/gear-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/core": "^7.17.8",

--- a/utils/gear-ui/package.json
+++ b/utils/gear-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React UI components used across Gear applications",
   "author": "Gear Technologies",
   "license": "GPL-3.0",

--- a/utils/gear-ui/rollup.config.js
+++ b/utils/gear-ui/rollup.config.js
@@ -30,5 +30,6 @@ export default [
     input: 'dist/esm/types/index.d.ts',
     output: [{ file: 'dist/index.d.ts', format: 'esm' }],
     plugins: [dts()],
+    external: [/\.scss$/],
   },
 ];

--- a/utils/gear-ui/src/components/Button/Button.tsx
+++ b/utils/gear-ui/src/components/Button/Button.tsx
@@ -1,16 +1,8 @@
 import clsx from 'clsx';
-import { ButtonProps } from './Button.types';
+import { Props } from './Button.types';
 import styles from './Button.module.scss';
 
-const Button = ({
-  text,
-  icon,
-  className,
-  type = 'button',
-  color = 'primary',
-  size = 'normal',
-  ...attrs
-}: ButtonProps) => {
+const Button = ({ text, icon, className, type = 'button', color = 'primary', size = 'normal', ...attrs }: Props) => {
   const buttonClassName = clsx(styles.button, className, styles[color], styles[text ? size : 'noText']);
 
   return (
@@ -21,4 +13,4 @@ const Button = ({
   );
 };
 
-export { Button };
+export { Button, Props as ButtonProps, styles as buttonStyles };

--- a/utils/gear-ui/src/components/Button/Button.types.ts
+++ b/utils/gear-ui/src/components/Button/Button.types.ts
@@ -15,4 +15,4 @@ interface IconProps extends BaseProps {
   icon: string;
 }
 
-export type ButtonProps = TextProps | IconProps;
+export type Props = TextProps | IconProps;

--- a/utils/gear-ui/src/components/Checkbox/Checkbox.tsx
+++ b/utils/gear-ui/src/components/Checkbox/Checkbox.tsx
@@ -2,12 +2,12 @@ import { InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Checkbox.module.scss';
 
-interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   type?: 'switch';
 }
 
-const Checkbox = ({ label, className, type, ...attrs }: CheckboxProps) => {
+const Checkbox = ({ label, className, type, ...attrs }: Props) => {
   const { disabled } = attrs;
   const labelClassName = clsx(styles.label, className, disabled && 'disabled');
   const inputClassName = clsx(styles.input, type === 'switch' ? styles.switch : styles.checkbox);
@@ -20,4 +20,4 @@ const Checkbox = ({ label, className, type, ...attrs }: CheckboxProps) => {
   );
 };
 
-export { Checkbox, CheckboxProps };
+export { Checkbox, Props as CheckboxProps, styles as checkboxStyles };

--- a/utils/gear-ui/src/components/Input/Input.tsx
+++ b/utils/gear-ui/src/components/Input/Input.tsx
@@ -3,12 +3,12 @@ import clsx from 'clsx';
 import { Icon, Text } from './children';
 import styles from './Input.module.scss';
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   icon?: string;
 }
 
-const Input = ({ label, icon, className, ...attrs }: InputProps) => {
+const Input = ({ label, icon, className, ...attrs }: Props) => {
   const { readOnly, disabled } = attrs;
   const labelClassName = clsx(styles.label, disabled && 'disabled', className);
   const wrapperClassName = clsx(styles.wrapper, readOnly && styles.readOnly);
@@ -24,4 +24,4 @@ const Input = ({ label, icon, className, ...attrs }: InputProps) => {
   );
 };
 
-export { Input, InputProps };
+export { Input, Props as InputProps, styles as inputStyles };

--- a/utils/gear-ui/src/components/Modal/Modal.module.scss
+++ b/utils/gear-ui/src/components/Modal/Modal.module.scss
@@ -12,12 +12,14 @@ $border: url("data:image/svg+xml,%3Csvg width='430' height='431' fill='none' xml
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0 32px;
   background-color: rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(15px);
   z-index: 10;
 }
 
 .modal {
+  width: 100%;
   max-width: 430px;
   padding: 30px 30px 70px;
   background: $bgColor $border center / 100% 100% no-repeat;
@@ -27,6 +29,11 @@ $border: url("data:image/svg+xml,%3Csvg width='430' height='431' fill='none' xml
 .button {
   margin-left: auto;
   margin-bottom: 24px;
+}
+
+.heading,
+.body {
+  padding: 0 35px;
 }
 
 .heading {

--- a/utils/gear-ui/src/components/Modal/Modal.test.tsx
+++ b/utils/gear-ui/src/components/Modal/Modal.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Modal } from './Modal';
+import styles from './Modal.module.scss';
 
 const close = jest.fn();
 
@@ -50,6 +51,18 @@ describe('modal tests', () => {
 
     expect(modal).toContainElement(body);
     expect(body).toContainElement(content);
+  });
+
+  it('applies className to body', () => {
+    render(
+      <Modal heading="test" close={close} className="testClassName">
+        modal content
+      </Modal>,
+    );
+
+    const body = screen.getByText('modal content');
+
+    expect(body).toHaveClass(styles.body, 'testClassName');
   });
 
   it('clicks close button', () => {

--- a/utils/gear-ui/src/components/Modal/Modal.tsx
+++ b/utils/gear-ui/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ReactNode, useEffect, useState, MouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '../Button/Button';
@@ -13,6 +14,7 @@ type Props = {
 
 const Modal = ({ heading, close, children, className }: Props) => {
   const [root, setRoot] = useState<HTMLDivElement>();
+  const bodyClassName = clsx(styles.body, className);
 
   const handleOverlayClick = ({ target, currentTarget }: MouseEvent) => {
     if (target === currentTarget) close();
@@ -35,7 +37,7 @@ const Modal = ({ heading, close, children, className }: Props) => {
         <Button className={styles.button} icon={icon} color="transparent" onClick={close} />
         <h3 className={styles.heading}>{heading}</h3>
         {children && (
-          <div className={className} data-testid="body">
+          <div className={bodyClassName} data-testid="body">
             {children}
           </div>
         )}

--- a/utils/gear-ui/src/components/Modal/Modal.tsx
+++ b/utils/gear-ui/src/components/Modal/Modal.tsx
@@ -4,14 +4,14 @@ import { Button } from '../Button/Button';
 import icon from './images/x.svg';
 import styles from './Modal.module.scss';
 
-type ModalProps = {
+type Props = {
   heading: string;
   close: () => void;
   children?: ReactNode;
   className?: string;
 };
 
-const Modal = ({ heading, close, children, className }: ModalProps) => {
+const Modal = ({ heading, close, children, className }: Props) => {
   const [root, setRoot] = useState<HTMLDivElement>();
 
   const handleOverlayClick = ({ target, currentTarget }: MouseEvent) => {
@@ -46,4 +46,4 @@ const Modal = ({ heading, close, children, className }: ModalProps) => {
   return root ? createPortal(component, root) : null;
 };
 
-export { Modal, ModalProps };
+export { Modal, Props as ModalProps, styles as modalStyles };

--- a/utils/gear-ui/src/components/Radio/Radio.tsx
+++ b/utils/gear-ui/src/components/Radio/Radio.tsx
@@ -2,11 +2,11 @@ import { InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Radio.module.scss';
 
-interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
 }
 
-const Radio = ({ label, className, ...attrs }: RadioProps) => {
+const Radio = ({ label, className, ...attrs }: Props) => {
   const { disabled } = attrs;
   const labelClassName = clsx(styles.label, className, disabled && 'disabled');
 
@@ -18,4 +18,4 @@ const Radio = ({ label, className, ...attrs }: RadioProps) => {
   );
 };
 
-export { Radio, RadioProps };
+export { Radio, Props as RadioProps, styles as radioStyles };

--- a/utils/gear-ui/src/components/Radio/RadioGroup.tsx
+++ b/utils/gear-ui/src/components/Radio/RadioGroup.tsx
@@ -1,11 +1,11 @@
 import { InputHTMLAttributes } from 'react';
 import { Radio, RadioProps } from './Radio';
 
-interface RadioGroupProps extends InputHTMLAttributes<HTMLInputElement> {
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   buttons: RadioProps[];
 }
 
-const RadioGroup = ({ buttons, value, ...attrs }: RadioGroupProps) => {
+const RadioGroup = ({ buttons, value, ...attrs }: Props) => {
   const getButtons = () =>
     buttons.map((button, index) => {
       const checked = value === button.value;
@@ -17,4 +17,4 @@ const RadioGroup = ({ buttons, value, ...attrs }: RadioGroupProps) => {
   return <>{getButtons()}</>;
 };
 
-export { RadioGroup, RadioGroupProps };
+export { RadioGroup, Props as RadioGroupProps };

--- a/utils/gear-ui/src/components/Select/Select.tsx
+++ b/utils/gear-ui/src/components/Select/Select.tsx
@@ -2,12 +2,12 @@ import { OptionHTMLAttributes, SelectHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Select.module.scss';
 
-interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
   options: OptionHTMLAttributes<HTMLOptionElement>[];
   label?: string;
 }
 
-const Select = ({ options, label, className, ...attrs }: SelectProps) => {
+const Select = ({ options, label, className, ...attrs }: Props) => {
   const { disabled } = attrs;
   const labelClassName = clsx(styles.label, className, disabled && 'disabled');
 
@@ -23,4 +23,4 @@ const Select = ({ options, label, className, ...attrs }: SelectProps) => {
   );
 };
 
-export { Select, SelectProps };
+export { Select, Props as SelectProps, styles as selectStyles };

--- a/utils/gear-ui/src/components/Textarea/Textarea.tsx
+++ b/utils/gear-ui/src/components/Textarea/Textarea.tsx
@@ -2,11 +2,11 @@ import { TextareaHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import styles from './Textarea.module.scss';
 
-interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
 }
 
-const Textarea = ({ label, className, rows = 5, ...attrs }: TextareaProps) => {
+const Textarea = ({ label, className, rows = 5, ...attrs }: Props) => {
   const { disabled } = attrs;
   const labelClassName = clsx(styles.label, className, disabled && 'disabled');
 
@@ -18,4 +18,4 @@ const Textarea = ({ label, className, rows = 5, ...attrs }: TextareaProps) => {
   );
 };
 
-export { Textarea, TextareaProps };
+export { Textarea, Props as TextareaProps, styles as textareaStyles };

--- a/utils/gear-ui/src/index.ts
+++ b/utils/gear-ui/src/index.ts
@@ -1,5 +1,4 @@
 export * from './components/Button/Button';
-export * from './components/Button/Button.types';
 export * from './components/Checkbox/Checkbox';
 export * from './components/Input/Input';
 export * from './components/Radio/Radio';


### PR DESCRIPTION
### Add:
- Styles export. Use example:
`import { buttonStyles } from '@gear-js/ui'`
`<button type='button' className={buttonStyles}>text</button>`

- Modal className test

### Fix:
- Modal paddings and min width