### PR TITLE
Add block prop to button

### DIFF
--- a/utils/gear-ui/package-lock.json
+++ b/utils/gear-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/ui",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/core": "^7.17.8",

--- a/utils/gear-ui/package.json
+++ b/utils/gear-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React UI components used across Gear applications",
   "author": "Gear Technologies",
   "license": "GPL-3.0",

--- a/utils/gear-ui/src/components/Button/Button.module.scss
+++ b/utils/gear-ui/src/components/Button/Button.module.scss
@@ -3,7 +3,7 @@
 
 .button {
   @include transition();
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-family: inherit;
@@ -16,6 +16,10 @@
     pointer-events: none;
     opacity: 0.5;
   }
+}
+
+.block {
+  width: 100%;
 }
 
 .normal {

--- a/utils/gear-ui/src/components/Button/Button.test.tsx
+++ b/utils/gear-ui/src/components/Button/Button.test.tsx
@@ -54,4 +54,10 @@ describe('button tests', () => {
     const button = screen.getByRole('button');
     expect(button).toHaveClass(styles.transparent);
   });
+
+  it('renders block button', () => {
+    render(<Button text="button text" block />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(styles.block);
+  });
 });

--- a/utils/gear-ui/src/components/Button/Button.tsx
+++ b/utils/gear-ui/src/components/Button/Button.tsx
@@ -2,8 +2,23 @@ import clsx from 'clsx';
 import { Props } from './Button.types';
 import styles from './Button.module.scss';
 
-const Button = ({ text, icon, className, type = 'button', color = 'primary', size = 'normal', ...attrs }: Props) => {
-  const buttonClassName = clsx(styles.button, className, styles[color], styles[text ? size : 'noText']);
+const Button = ({
+  text,
+  icon,
+  className,
+  block,
+  type = 'button',
+  color = 'primary',
+  size = 'normal',
+  ...attrs
+}: Props) => {
+  const buttonClassName = clsx(
+    styles.button,
+    className,
+    styles[color],
+    styles[text ? size : 'noText'],
+    block && styles.block,
+  );
 
   return (
     <button type={type} className={buttonClassName} {...attrs}>

--- a/utils/gear-ui/src/components/Button/Button.types.ts
+++ b/utils/gear-ui/src/components/Button/Button.types.ts
@@ -5,6 +5,7 @@ interface BaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: string;
   color?: 'primary' | 'secondary' | 'transparent';
   size?: 'normal' | 'small';
+  block?: boolean;
 }
 
 interface TextProps extends BaseProps {


### PR DESCRIPTION
`Button` component now has `display: inline-flex` by default, with the ability to specify `block` prop to take the full width of it's container.