### PR TITLE
Optimize requests connected with metadata

### DIFF
--- a/website/data-storage/src/consumer/consumer.service.ts
+++ b/website/data-storage/src/consumer/consumer.service.ts
@@ -26,6 +26,7 @@ import {
   InitFailure,
   GetAllUserProgramsParams,
   IGenesis,
+  ProgramDataResult,
 } from '@gear-js/interfaces';
 import { FormResponse } from 'src/middleware/formResponse';
 
@@ -90,7 +91,7 @@ export class ConsumerService {
   };
 
   @FormResponse
-  async programData(params: FindProgramParams): Result<IProgram> {
+  async programData(params: FindProgramParams): Result<ProgramDataResult> {
     return await this.programService.findProgram(params);
   }
 

--- a/website/data-storage/src/entities/program.entity.ts
+++ b/website/data-storage/src/entities/program.entity.ts
@@ -15,9 +15,6 @@ export class Program extends BaseEntity implements IProgram {
   @Column()
   name: string;
 
-  @Column({ nullable: true })
-  uploadedAt: Date;
-
   @OneToOne(() => Meta, { nullable: true, onDelete: 'CASCADE' })
   @JoinColumn()
   meta: Meta;

--- a/website/data-storage/src/metadata/metadata.service.ts
+++ b/website/data-storage/src/metadata/metadata.service.ts
@@ -38,10 +38,13 @@ export class MetadataService {
   }
 
   async getMeta(params: GetMetaParams): Promise<GetMetaResult> {
-    const meta = await this.metaRepo.findOne({ where: { program: params.programId } });
+    const meta = await this.metaRepo.findOne({
+      where: { program: params.programId },
+      select: ['program', 'meta', 'metaFile'],
+    });
     if (!meta) {
       throw new MetadataNotFound();
     }
-    return { program: meta.program, meta: meta.meta, metaFile: meta.metaFile };
+    return meta;
   }
 }

--- a/website/data-storage/src/programs/programs.service.ts
+++ b/website/data-storage/src/programs/programs.service.ts
@@ -5,6 +5,7 @@ import {
   GetAllProgramsParams,
   GetAllProgramsResult,
   GetAllUserProgramsParams,
+  ProgramDataResult,
 } from '@gear-js/interfaces';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -78,10 +79,24 @@ export class ProgramsService {
     };
   }
 
-  async findProgram(params: FindProgramParams): Promise<IProgram> {
+  async findProgram(params: FindProgramParams): Promise<ProgramDataResult> {
     const { id, genesis, owner } = params;
     const where = owner ? { id, genesis, owner } : { id, genesis };
-    const program = await this.programRepo.findOne({ where, relations: ['meta'] });
+    const program = await this.programRepo.findOne({
+      where,
+      select: {
+        id: true,
+        genesis: true,
+        blockHash: true,
+        timestamp: true,
+        owner: true,
+        name: true,
+        initStatus: true,
+        title: true,
+        meta: { meta: true },
+      },
+      relations: ['meta'],
+    });
     if (!program) {
       throw new ProgramNotFound();
     }

--- a/website/interfaces/src/api-response.ts
+++ b/website/interfaces/src/api-response.ts
@@ -1,4 +1,3 @@
-import { IGenesis } from './general';
 import { IMessage } from './message';
 import { IPaginationResult } from './pagination';
 import { IProgram } from './program';
@@ -19,4 +18,8 @@ export interface GetMetaResult {
   program: string;
   meta: string;
   metaFile: string;
+}
+
+export interface ProgramDataResult extends Omit<IProgram, 'meta'> {
+  meta?: { meta?: string };
 }


### PR DESCRIPTION
## Changes
- `program.data` method now does not return the metaFile and other unneccessary fields. So if you need to get a metaFile of a particular program use the `program.meta.get` method.
- Drop `uploadedAt` field from program entity