### PR TITLE
Fix paymentInfo argument type

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.24.2
+
+_07/27/2022_
+
+https://github.com/gear-tech/gear-js/pull/894
+
+### Changes
+
+- Fix type of `paymentInfo` method's argument.
+
+---
 ## 0.24.1
 
 _07/22/2022_

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gear-js/api",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gear-js/api",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@babel/plugin-transform-typescript": "7.18.8",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/src/Transaction.ts
+++ b/api/src/Transaction.ts
@@ -61,7 +61,7 @@ export class GearTransaction {
    * consolg.log(transactionFee);
    * ```
    */
-  paymentInfo(account: AddressOrPair, options?: SignerOptions): Promise<RuntimeDispatchInfo> {
+  paymentInfo(account: AddressOrPair, options?: Partial<SignerOptions>): Promise<RuntimeDispatchInfo> {
     return this.submitted.paymentInfo(account, options);
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "@types/react": "17.0.44"
   },
   "packageManager": "yarn@3.2.0",
-  "version": "1.2.1"
+  "version": "1.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "@types/react": "17.0.44"
   },
   "packageManager": "yarn@3.2.0",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
### Changes

- Fix type of `paymentInfo` method's argument.
---
### Bump `gear-js/api` version to `0.24.2`