### PR TITLE
Bump @polkadot/api to 9.14.1

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.30.0
+
+_02/15/2023_
+
+https://github.com/gear-tech/gear-js/pull/1204
+
+### Changes
+
+- Bump `@polkadot/api` to `9.14.1`.
+
 ## 0.29.5
 
 _02/14/2023_

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
   },
   "license": "GPL-3.0",
   "peerDependencies": {
-    "@polkadot/api": "^9.11.1",
+    "@polkadot/api": "^9.14.1",
     "@polkadot/wasm-crypto": "^6.4.1",
     "rxjs": "^7.5.5"
   },
@@ -54,8 +54,8 @@
     "@babel/plugin-transform-typescript": "7.20.2",
     "@babel/preset-env": "7.20.2",
     "@babel/preset-typescript": "7.18.6",
-    "@polkadot/api": "9.11.1",
-    "@polkadot/types": "9.11.1",
+    "@polkadot/api": "9.14.1",
+    "@polkadot/types": "9.14.1",
     "@polkadot/wasm-crypto": "6.4.1",
     "@rollup/plugin-commonjs": "22.0.2",
     "@rollup/plugin-json": "4.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.29.5",
+  "version": "0.30.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/test/Waitlist.test.ts
+++ b/api/test/Waitlist.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   await api.isReadyOrError;
   const code = readFileSync(CODE_PATH);
   alice = (await getAccount())[0];
-  programId = api.program.upload({ code, gasLimit: 2_000_000_000 }).programId;
+  programId = api.program.upload({ code, gasLimit: 20_000_000_000 }).programId;
   const init = checkInit(api, programId);
   await sendTransaction(api.program, alice, 'MessageQueued');
   expect(await init()).toBe('success');
@@ -33,7 +33,7 @@ afterAll(async () => {
 
 describe('GearWaitlist', () => {
   test("read program's waitlist", async () => {
-    api.message.send({ destination: programId, payload: '0x00', gasLimit: 2_000_000_000 });
+    api.message.send({ destination: programId, payload: '0x00', gasLimit: 20_000_000_000 });
     messageId = (await sendTransaction(api.message, alice, 'MessageQueued')).id;
     const eventData = await messageWaited(messageId);
     expect(eventData).toBeDefined();
@@ -64,7 +64,7 @@ describe('GearWaitlist', () => {
   });
 
   test("send one more message and read program's waitlist", async () => {
-    api.message.send({ destination: programId, payload: '0x00', gasLimit: 2_000_000_000 });
+    api.message.send({ destination: programId, payload: '0x00', gasLimit: 20_000_000_000 });
     messageId = (await sendTransaction(api.message, alice, 'MessageQueued'))[0];
     const waitlist = await api.waitlist.read(programId);
     expect(waitlist).toHaveLength(2);

--- a/api/test/programs/Cargo.lock
+++ b/api/test/programs/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.4"
-source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=e76ae98#e76ae9869ea4d386e758d7ed5d983ba2a25d7629"
+source = "git+https://github.com/gear-tech/dlmalloc-rust.git?rev=9135baa#9135baa728ef9a9a04a887998e019733c4b093af"
 dependencies = [
  "libc",
  "libc_print",
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "galloc"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "dlmalloc",
 ]
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "gear-core-errors",
  "gsys",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "gear-core-errors"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "derive_more",
  "enum-iterator",
@@ -318,7 +318,7 @@ dependencies = [
 [[package]]
 name = "gear-wasm-builder"
 version = "0.1.2"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "gmeta"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "blake2-rfc",
  "gmeta-codegen",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "gmeta-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "gstd"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "bs58",
  "futures",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "gstd-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "gsys"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#b87fa814967677d1b484ea0a90b76bd48d4b6394"
+source = "git+https://github.com/gear-tech/gear.git#67d856fe75939cd7b1bd494791a1c77199f8f1e5"
 
 [[package]]
 name = "hashbrown"
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "page_size"

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1289,7 +1289,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.20.13":
+  version: 7.20.13
+  resolution: "@babel/runtime@npm:7.20.13"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 09b7a97a05c80540db6c9e4ddf8c5d2ebb06cae5caf3a87e33c33f27f8c4d49d9c67a2d72f1570e796045288fad569f98a26ceba0c4f5fad2af84b6ad855c4fb
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.8.4":
   version: 7.20.7
   resolution: "@babel/runtime@npm:7.20.7"
   dependencies:
@@ -1385,8 +1394,8 @@ __metadata:
     "@babel/plugin-transform-typescript": 7.20.2
     "@babel/preset-env": 7.20.2
     "@babel/preset-typescript": 7.18.6
-    "@polkadot/api": 9.11.1
-    "@polkadot/types": 9.11.1
+    "@polkadot/api": 9.14.1
+    "@polkadot/types": 9.14.1
     "@polkadot/wasm-crypto": 6.4.1
     "@rollup/plugin-commonjs": 22.0.2
     "@rollup/plugin-json": 4.1.0
@@ -1408,7 +1417,7 @@ __metadata:
     ts-node: 10.9.1
     typescript: 4.9.3
   peerDependencies:
-    "@polkadot/api": ^9.11.1
+    "@polkadot/api": ^9.14.1
     "@polkadot/wasm-crypto": ^6.4.1
     rxjs: ^7.5.5
   languageName: unknown
@@ -1751,17 +1760,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.1.5":
-  version: 1.1.5
-  resolution: "@noble/hashes@npm:1.1.5"
-  checksum: de3f095a7ac1cbf5b4b3d09f193288d4f2eec35fbadf2ed9fd7e47d8a3042fef410052ba62dc0296a185f994c11192f5357fdb1bd9178c905efd82e946c53b00
+"@noble/hashes@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@noble/hashes@npm:1.2.0"
+  checksum: 8ca080ce557b8f40fb2f78d3aedffd95825a415ac8e13d7ffe3643f8626a8c2d99a3e5975b555027ac24316d8b3c02a35b8358567c0c23af681e6573602aa434
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@noble/secp256k1@npm:1.7.0"
-  checksum: 540a2b8e527ee1e5522af1c430e54945ad373883cac983b115136cd0950efa1f2c473ee6a36d8e69b6809b3ee586276de62f5fa705c77a9425721e81bada8116
+"@noble/secp256k1@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@noble/secp256k1@npm:1.7.1"
+  checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
   languageName: node
   linkType: hard
 
@@ -1812,260 +1821,260 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/api-augment@npm:9.11.1"
+"@polkadot/api-augment@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/api-augment@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/api-base": 9.11.1
-    "@polkadot/rpc-augment": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-augment": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/util": ^10.2.3
-  checksum: a296ccbd763ed2479b0310789d9b8ba723806568a7af95122ea87a0003a3c4e60e816441d70cf9d316911c5e80db94c6c639b63a8823e34470409f4d74c5f11f
+    "@babel/runtime": ^7.20.13
+    "@polkadot/api-base": 9.14.1
+    "@polkadot/rpc-augment": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-augment": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/util": ^10.4.1
+  checksum: 4a2770c47786efde09e43dfa7cc70887036e20a7246ac723cb8b595c9ba5e5fce633622ad72dece50ea92245c467bf70f00234eb33aa5b522f6a531132420e95
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/api-base@npm:9.11.1"
+"@polkadot/api-base@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/api-base@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/rpc-core": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/util": ^10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/rpc-core": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/util": ^10.4.1
     rxjs: ^7.8.0
-  checksum: b23254f1dfdd62fd226236b6bd0046e5406a132a39a60d3265677422102eac738a7010299d3fcfa70231de8cde8ed9456feb207074c7c3575e14b5cca2c48a3b
+  checksum: 213f775da835336f1405f335889e951a6918cded4fdfa1f534319f46e3033d8c616fd1a8d5a1d963fd3be1d71a7a2d397b948ec051625a4b8e9759d2bd22fec4
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/api-derive@npm:9.11.1"
+"@polkadot/api-derive@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/api-derive@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/api": 9.11.1
-    "@polkadot/api-augment": 9.11.1
-    "@polkadot/api-base": 9.11.1
-    "@polkadot/rpc-core": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/util": ^10.2.3
-    "@polkadot/util-crypto": ^10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/api": 9.14.1
+    "@polkadot/api-augment": 9.14.1
+    "@polkadot/api-base": 9.14.1
+    "@polkadot/rpc-core": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/util": ^10.4.1
+    "@polkadot/util-crypto": ^10.4.1
     rxjs: ^7.8.0
-  checksum: f8b04fc67a8261df37ac6cb4a1d6285caddbde27fb68ccb439c8d34ab34ac69b50cdef88b36378cd68441a7acc1b6b8d0c2043fff2c8d04c1da0a19881a9612c
+  checksum: 55943646c70cfa80e91d22d2a8b607933517c8a096a2fba621de3b8dddac6e3e654d560c535b28c74868524efe4536fb6db29bbb4ac733d0139240856e985da8
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/api@npm:9.11.1"
+"@polkadot/api@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/api@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/api-augment": 9.11.1
-    "@polkadot/api-base": 9.11.1
-    "@polkadot/api-derive": 9.11.1
-    "@polkadot/keyring": ^10.2.3
-    "@polkadot/rpc-augment": 9.11.1
-    "@polkadot/rpc-core": 9.11.1
-    "@polkadot/rpc-provider": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-augment": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/types-create": 9.11.1
-    "@polkadot/types-known": 9.11.1
-    "@polkadot/util": ^10.2.3
-    "@polkadot/util-crypto": ^10.2.3
-    eventemitter3: ^4.0.7
+    "@babel/runtime": ^7.20.13
+    "@polkadot/api-augment": 9.14.1
+    "@polkadot/api-base": 9.14.1
+    "@polkadot/api-derive": 9.14.1
+    "@polkadot/keyring": ^10.4.1
+    "@polkadot/rpc-augment": 9.14.1
+    "@polkadot/rpc-core": 9.14.1
+    "@polkadot/rpc-provider": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-augment": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/types-create": 9.14.1
+    "@polkadot/types-known": 9.14.1
+    "@polkadot/util": ^10.4.1
+    "@polkadot/util-crypto": ^10.4.1
+    eventemitter3: ^5.0.0
     rxjs: ^7.8.0
-  checksum: 18b2dd1a69e56e8bb1864f0691d4a4dedfaafa4b5e54eeb76e17b210d4f8c3793bb86569d165217c3595ef076d9084f841ec40e18147d3bfdd479cc5b5e5204c
+  checksum: e11ebdc32d74730e505371e83c2080774cdb1b00cb61e8b81eaab62761806238a84ce85a1cf5abef1ae166f412c2cad7748e49e123f17340aae87d809172662d
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/keyring@npm:10.2.3"
+"@polkadot/keyring@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/keyring@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/util": 10.2.3
-    "@polkadot/util-crypto": 10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/util": 10.4.1
+    "@polkadot/util-crypto": 10.4.1
   peerDependencies:
-    "@polkadot/util": 10.2.3
-    "@polkadot/util-crypto": 10.2.3
-  checksum: f9f8d30f2a6878075f651fde2e689de1cc7dab537047906ae7169b6758cef7dadb6c0eac7831c27a7243c33e4a951500dc5b4380e1837bedc4e6a8557cfda5fc
+    "@polkadot/util": 10.4.1
+    "@polkadot/util-crypto": 10.4.1
+  checksum: 5454dee33fadc5de8866502cade33d1502d85896f53aaa937683c456b09cb7fda5a05e45bca3a26a22a5c3743306dbc0665977d842d83e453a32c983a40eee15
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:10.2.3, @polkadot/networks@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/networks@npm:10.2.3"
+"@polkadot/networks@npm:10.4.1, @polkadot/networks@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/networks@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/util": 10.2.3
-    "@substrate/ss58-registry": ^1.37.0
-  checksum: 0697f6be7449f55d5f980973fb432f08681786c51e2a532f9887b44f9a7c26d5ba3938b2658fa7258027a70f955af7058c6ec9c13b8167257e6e3c565b3c33d5
+    "@babel/runtime": ^7.20.13
+    "@polkadot/util": 10.4.1
+    "@substrate/ss58-registry": ^1.38.0
+  checksum: d269316ae3b10bc72895040006f7328af470e5040ee04a8acc5f01c25b0b39995e3d24020b2a3ac6bb358290cec3ccb2a3ee6c79eda086a8a6c4fffd40527e62
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/rpc-augment@npm:9.11.1"
+"@polkadot/rpc-augment@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/rpc-augment@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/rpc-core": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/util": ^10.2.3
-  checksum: 27a13d4730d00798bf52ae99e216591af0cb3b1413a35ea790aa66a19043b85f615ad2d3d333bd5cc23f2975342be53f7288b9d7bef78ebc1d1b91e35fcb09aa
+    "@babel/runtime": ^7.20.13
+    "@polkadot/rpc-core": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/util": ^10.4.1
+  checksum: 1d4f29f29fbc927570417bbb278cb469585e5e129fa56144805056fa8a8c174b7f74d36a9dace4e544d473b7b164accc6be63594e2fd3f870fe23bdb1a65d519
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/rpc-core@npm:9.11.1"
+"@polkadot/rpc-core@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/rpc-core@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/rpc-augment": 9.11.1
-    "@polkadot/rpc-provider": 9.11.1
-    "@polkadot/types": 9.11.1
-    "@polkadot/util": ^10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/rpc-augment": 9.14.1
+    "@polkadot/rpc-provider": 9.14.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/util": ^10.4.1
     rxjs: ^7.8.0
-  checksum: 3446ae5b7ea347bac42e5e173310b9a8ed5eef95aa88ff61edfb09c07e5b1bdef9d90b2d776a4e295d844f78d2c8aa5bafb63d77c423cbd09e53aa35115295c0
+  checksum: 1afd707e088f2f69d800a84aaf87a4f30647f6663923ef78169342bef92623d008c83b5abe6a568221a673d61aea399d9ae44f2fd064742314f258095b039ae3
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/rpc-provider@npm:9.11.1"
+"@polkadot/rpc-provider@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/rpc-provider@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/keyring": ^10.2.3
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-support": 9.11.1
-    "@polkadot/util": ^10.2.3
-    "@polkadot/util-crypto": ^10.2.3
-    "@polkadot/x-fetch": ^10.2.3
-    "@polkadot/x-global": ^10.2.3
-    "@polkadot/x-ws": ^10.2.3
-    "@substrate/connect": 0.7.18
-    eventemitter3: ^4.0.7
-    mock-socket: ^9.1.5
-    nock: ^13.2.9
+    "@babel/runtime": ^7.20.13
+    "@polkadot/keyring": ^10.4.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-support": 9.14.1
+    "@polkadot/util": ^10.4.1
+    "@polkadot/util-crypto": ^10.4.1
+    "@polkadot/x-fetch": ^10.4.1
+    "@polkadot/x-global": ^10.4.1
+    "@polkadot/x-ws": ^10.4.1
+    "@substrate/connect": 0.7.19
+    eventemitter3: ^5.0.0
+    mock-socket: ^9.2.0
+    nock: ^13.3.0
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: a8273a9f018138f2bb96fd6381b843f31120974391db0bfbbb02624a71bf2f082bc8afaf12f0628d0f6b71c12e52574722d64046ce3efafb261c7cab0f28b46c
+  checksum: d1a4ffdcbf335e539763856ff656665041f2311afe3056deb712b27125a9b0039cb57fffc48de0002ac951b81d4b38271d98b04be21ff113d361c470ef9e352e
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types-augment@npm:9.11.1"
+"@polkadot/types-augment@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types-augment@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/util": ^10.2.3
-  checksum: 55ba5edb217b2dcb73065bd744b7822d98f4aa7b0181cf65b89e506c79eb6d28d4ebd96f97229b6ed54f8fa41aee064d23f91aa6a600370f50f33b9ed3ce60d7
+    "@babel/runtime": ^7.20.13
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/util": ^10.4.1
+  checksum: d336a178161495b0f75ea1ad79f68cd139eedfa19cbc202cd1036d244d57eea978ea7df8b16d9dfd9d4147da1f7da08cc091ccab37663948a42aa54dcd67a8d2
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types-codec@npm:9.11.1"
+"@polkadot/types-codec@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types-codec@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/util": ^10.2.3
-    "@polkadot/x-bigint": ^10.2.3
-  checksum: aedb21c9f0589374de4361c338a93d297b9021ca0dd7be34f8bc64f09809a3657685dc53ece4e0f663162f94db830b47061c9762a238b7f757c1cf51bbfff254
+    "@babel/runtime": ^7.20.13
+    "@polkadot/util": ^10.4.1
+    "@polkadot/x-bigint": ^10.4.1
+  checksum: 0e30b217bd899a363d9e5e0d10218c44ce16bbb62edab172cdd7821b2cae464345e0fcefd740e111048795688d66caa8935e33c80f99ec5b9edb4011ad7433d4
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types-create@npm:9.11.1"
+"@polkadot/types-create@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types-create@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/util": ^10.2.3
-  checksum: 761fe9839bd73d75140489e00dfceb0b816e4bad13db89231fb715488cb27ff48178adffe5169c13ee4c9b088efaf1a433b07fb1641ce680aa54a156b37e9f0f
+    "@babel/runtime": ^7.20.13
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/util": ^10.4.1
+  checksum: 5cbd8d4007e382889204d50b66a70b84cd80a5b1dc61fc0419c0c4a49d4d5d9b3d9f555ce7b9e58bebc969b0a85f59acaedbd728f5dc2213bc1b1d59b62557a5
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types-known@npm:9.11.1"
+"@polkadot/types-known@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types-known@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/networks": ^10.2.3
-    "@polkadot/types": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/types-create": 9.11.1
-    "@polkadot/util": ^10.2.3
-  checksum: b1708b17f691d88092c107761a61d27e9b1867cb54fb4f911093ca8d56603337d38bd51b9b9fc9622b95fa4b260b09bef638c9b0f108b277a4c3e7589b1a7946
+    "@babel/runtime": ^7.20.13
+    "@polkadot/networks": ^10.4.1
+    "@polkadot/types": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/types-create": 9.14.1
+    "@polkadot/util": ^10.4.1
+  checksum: 66d50496b091c725247f9d624bc2b73b7ca271000e63a3228dc009ad31a12d6f266787d303af72af109a847f14f0def28e90d193fc66113f082f5328700f3e64
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types-support@npm:9.11.1"
+"@polkadot/types-support@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types-support@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/util": ^10.2.3
-  checksum: 1b14ed0b5f2a5190a04b19eb94d1eb35a5f08d50ba6c284e4cbf1b94ba15994024b8ace7e71e309dda5d7bea5f2916dcfebf6199d98cadf9ae69ae69f49d9bce
+    "@babel/runtime": ^7.20.13
+    "@polkadot/util": ^10.4.1
+  checksum: 5f6bfc08beb2a4410845e0616d5e8cb76a61dfc2dd6f89e9616c7aafd2e0ae9724e0fb43bc9de48f8e9752bd4140d27b5f02f4dc1cdaf4eb07312e844d2868e8
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:9.11.1":
-  version: 9.11.1
-  resolution: "@polkadot/types@npm:9.11.1"
+"@polkadot/types@npm:9.14.1":
+  version: 9.14.1
+  resolution: "@polkadot/types@npm:9.14.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/keyring": ^10.2.3
-    "@polkadot/types-augment": 9.11.1
-    "@polkadot/types-codec": 9.11.1
-    "@polkadot/types-create": 9.11.1
-    "@polkadot/util": ^10.2.3
-    "@polkadot/util-crypto": ^10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/keyring": ^10.4.1
+    "@polkadot/types-augment": 9.14.1
+    "@polkadot/types-codec": 9.14.1
+    "@polkadot/types-create": 9.14.1
+    "@polkadot/util": ^10.4.1
+    "@polkadot/util-crypto": ^10.4.1
     rxjs: ^7.8.0
-  checksum: 4cb11b7330c50c42c2f819894a459f1a06fb41f284ed3dfb7b08fb667545a995c9f902bd5470f078d969ea1904aee3fd0e5339153c97b6f6483e4b394864feda
+  checksum: 7cdadd1d413755cecd266dd63e5d3588dd927daa1430a3d8a5f916264214dd9abb1cd8b474be940f4d6215288e60d250e492664b719f0298cff067e0d26821cc
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:10.2.3, @polkadot/util-crypto@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/util-crypto@npm:10.2.3"
+"@polkadot/util-crypto@npm:10.4.1, @polkadot/util-crypto@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/util-crypto@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@noble/hashes": 1.1.5
-    "@noble/secp256k1": 1.7.0
-    "@polkadot/networks": 10.2.3
-    "@polkadot/util": 10.2.3
+    "@babel/runtime": ^7.20.13
+    "@noble/hashes": 1.2.0
+    "@noble/secp256k1": 1.7.1
+    "@polkadot/networks": 10.4.1
+    "@polkadot/util": 10.4.1
     "@polkadot/wasm-crypto": ^6.4.1
-    "@polkadot/x-bigint": 10.2.3
-    "@polkadot/x-randomvalues": 10.2.3
+    "@polkadot/x-bigint": 10.4.1
+    "@polkadot/x-randomvalues": 10.4.1
     "@scure/base": 1.1.1
     ed2curve: ^0.3.0
     tweetnacl: ^1.0.3
   peerDependencies:
-    "@polkadot/util": 10.2.3
-  checksum: 3c672893f8c986fadf15fe6c62a95e422eb789e6abe41950074624452e66e5269b035056d3120783801df56d118f9be80a4e40a583ad398678950ad11d7ee42e
+    "@polkadot/util": 10.4.1
+  checksum: 3ddc28b1ebdcd29ad5773b28e1aa02b337b4157120169385dc4fc41ae85656793ca561c7d5fe32b74a707289c52b1160e5bcbb670ed560b41b58e46636fe2626
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:10.2.3, @polkadot/util@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/util@npm:10.2.3"
+"@polkadot/util@npm:10.4.1, @polkadot/util@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/util@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-bigint": 10.2.3
-    "@polkadot/x-global": 10.2.3
-    "@polkadot/x-textdecoder": 10.2.3
-    "@polkadot/x-textencoder": 10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-bigint": 10.4.1
+    "@polkadot/x-global": 10.4.1
+    "@polkadot/x-textdecoder": 10.4.1
+    "@polkadot/x-textencoder": 10.4.1
     "@types/bn.js": ^5.1.1
     bn.js: ^5.2.1
-  checksum: 466ae121352fffc9aad5b5e3f3eea665678fd6b18f864b77545ce54a794f3a1986e861442beb7eb469163c50069fb0b4675228332f24f04e8dc91b3be475afa5
+  checksum: 1e375e24c5f34a4a3dda21f7f42f7830bd7e6d0536c466e97016567944810be6e89ab511d5d2f2d6053c2276ae2ccfccb7f64a476507d285653806031f34a939
   languageName: node
   linkType: hard
 
@@ -2147,76 +2156,76 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:10.2.3, @polkadot/x-bigint@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-bigint@npm:10.2.3"
+"@polkadot/x-bigint@npm:10.4.1, @polkadot/x-bigint@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-bigint@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
-  checksum: 08c6c739aae1e597e073b301b2f32c1b2f6ec7d9f7ce056106977da2036a4f167d4276e7ed8a8f10f0753804573b39b365d943941f6902f9c32ebf091be0b725
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
+  checksum: 596935c0fad4dbc038f2ac053794a9572369327006ef69e66944b76d0a92c1d1e2ba74ba90dc43fb91af6e2718dc1349dd7590ae085ab6c1a3841ef697a47bdc
   languageName: node
   linkType: hard
 
-"@polkadot/x-fetch@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-fetch@npm:10.2.3"
+"@polkadot/x-fetch@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-fetch@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
     "@types/node-fetch": ^2.6.2
     node-fetch: ^3.3.0
-  checksum: e5b03392efc2df782c684b4a64bb733ed2d11bfd1a9e47dac3bde6456110743cf4a70718b799eb2be7044c2e963f598e944f98c8dbe4f27e278a2f95dab6aa90
+  checksum: 0234da93947239122bd3f6a11b2c024814dfa8d31b96cda3d2d83cafe83189de16d4ca0be13dd69688ef8e4bce18c24c799536540a24244322cb67d8d12cfd44
   languageName: node
   linkType: hard
 
-"@polkadot/x-global@npm:10.2.3, @polkadot/x-global@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-global@npm:10.2.3"
+"@polkadot/x-global@npm:10.4.1, @polkadot/x-global@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-global@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-  checksum: 4bd4d9b3bed8ed9ed1bf7905821b20598b83d5621920bb78d59a618e4f0bb6f0effbe1b4d3d51ee70bc414d6b7c50e470b36276292e3551ff14f82fe07fb77c4
+    "@babel/runtime": ^7.20.13
+  checksum: 5e59c4f96f0701e7c036482a0a96d8d365630a8880cf465ebc3b25eb785bf488dbc45f0613423c169ffcfec00065de1add8b9ab8eb3ed3aa2cfaa8102310a09e
   languageName: node
   linkType: hard
 
-"@polkadot/x-randomvalues@npm:10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-randomvalues@npm:10.2.3"
+"@polkadot/x-randomvalues@npm:10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-randomvalues@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
-  checksum: a22b9a02609836276d36032445b3c0d17986bd61fa067549319ca4b1ed4b08c748830d88753a5658ed26e17cac8cbec3b81c4e122da7f8e0a0e59597de2a4cf1
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
+  checksum: 822a5fefd1f858e221cafc5ef03967758976abcb6f6b5a7a5ef499688a02a339c72e66012ddd8370650b2e708b46d2db7976d7a6031b25bea7b54d0dcf802389
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-textdecoder@npm:10.2.3"
+"@polkadot/x-textdecoder@npm:10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-textdecoder@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
-  checksum: 0617b756f3d88bf3e31cf52b7080fdd4c62f5c024242d1870c3428dea6906d6d30993b4c7271df886be8ab1370e79b177c59c9c9759e7ce81e3b13309fcc7906
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
+  checksum: 4295d04add17706bfa723c4e27e355ec0d85e5ba13f5d33709743d33255d99c5cc0ba9fc25a8249387ab878266ba75521a9388d03dbf1678dcffa6cbc4080c17
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-textencoder@npm:10.2.3"
+"@polkadot/x-textencoder@npm:10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-textencoder@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
-  checksum: eb1412fd5d79209bbeda80c758224a0605eb67aecbda412e31a93796e471bf4bd5d0e027b9e8aac881c71ad874ba9239e85465c30d217aa289654112188657ec
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
+  checksum: 343cef41910a2d764519454b745bf61b446afd006e414eafc6ea8270b366a918e72a1592c865eeea65471927bbd49a1db20f6a496d6ba32d3a870f886aa640a6
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^10.2.3":
-  version: 10.2.3
-  resolution: "@polkadot/x-ws@npm:10.2.3"
+"@polkadot/x-ws@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@polkadot/x-ws@npm:10.4.1"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    "@polkadot/x-global": 10.2.3
+    "@babel/runtime": ^7.20.13
+    "@polkadot/x-global": 10.4.1
     "@types/websocket": ^1.0.5
     websocket: ^1.0.34
-  checksum: 6c3512105296fac47fa3f3fc9098d3b4bd76a2ca976c0c9cba309bd5a9ae426a5ee483dde0fbaa4a98ec73c15e8325bf643ddd984f2b7e59c7bb9f6e6ae9774b
+  checksum: 39d7b79cec721ca1c5ce7ff21b0a04f047331768c095551b989cf1f29461275430e9dd41c1f67de426d57ad99799756763f0c349dba2cd9036923e4bbc0d68c7
   languageName: node
   linkType: hard
 
@@ -2343,14 +2352,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.18":
-  version: 0.7.18
-  resolution: "@substrate/connect@npm:0.7.18"
+"@substrate/connect@npm:0.7.19":
+  version: 0.7.19
+  resolution: "@substrate/connect@npm:0.7.19"
   dependencies:
     "@substrate/connect-extension-protocol": ^1.0.1
     "@substrate/smoldot-light": 0.7.9
     eventemitter3: ^4.0.7
-  checksum: cc3e189d3ceffc30b5a89b4575c76371f7b0dd620180f4846b784a168b459b37bb2017bd273de63a199a2d14cffbeabf67b0c8ae8db0fc7252297c9129902ebc
+  checksum: 7ac4b6bb791e7941464c29a46a77ce87da7c36e43ffdf42dc3e1b747813653376dc56e4c21032cbf3c935fdafc98f5428feb10904406195a82d296065abb633d
   languageName: node
   linkType: hard
 
@@ -2364,10 +2373,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.37.0":
-  version: 1.37.0
-  resolution: "@substrate/ss58-registry@npm:1.37.0"
-  checksum: c70f9109318a53813b75db664bcc10738b407fd5dd9df1e9cb24a49157f6037b67061d9dc81a0174ec9281032277fdf2fef00a16ed8092bd35afa60061e6bfdd
+"@substrate/ss58-registry@npm:^1.38.0":
+  version: 1.38.0
+  resolution: "@substrate/ss58-registry@npm:1.38.0"
+  checksum: 3c653b67b59f7c2d1653e64a5e04fd75f17ab442236d6638abd7ae2850717318a7c7840c6c1263f474f1a95e9c9e7f87131171513cd2ce42afeac68179978720
   languageName: node
   linkType: hard
 
@@ -4176,6 +4185,13 @@ __metadata:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "eventemitter3@npm:5.0.0"
+  checksum: b974bafbab860e0a5bbb21add4c4e82f9d5691c583c03f2e4c5d44a2d6c4556d79223621bdcfc6c8e14366a4af9df6b5ea9d6caf65fbffc80b66f3e1dceacbc9
   languageName: node
   linkType: hard
 
@@ -6385,10 +6401,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-socket@npm:^9.1.5":
-  version: 9.1.5
-  resolution: "mock-socket@npm:9.1.5"
-  checksum: a01586bc2850eb5809eda6de0c7ab19255c1e0eb217a805f86ba662bb4aab00b919032d67e7c826c6c12bcfb2fbe19cecbacf0ab6184936487edc4ba37d3ba53
+"mock-socket@npm:^9.2.0":
+  version: 9.2.1
+  resolution: "mock-socket@npm:9.2.1"
+  checksum: daf07689563163dbcefbefe23b2a9784a75d0af31706f23ad535c6ab2abbcdefa2e91acddeb50a3c39009139e47a8f909cbb38e8137452193ccb9331637fee3e
   languageName: node
   linkType: hard
 
@@ -6462,7 +6478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.2.9":
+"nock@npm:^13.3.0":
   version: 13.3.0
   resolution: "nock@npm:13.3.0"
   dependencies:


### PR DESCRIPTION
### Changes

- Bump `@polkadot/api` to `9.14.1`.
---
### Bump version to `0.30.0`