### PR TITLE
Use Bytes as default type, if meta or type wasn't specified. 

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.30.2
+
+_03/24/2023_
+
+https://github.com/gear-tech/gear-js/pull/1241
+
+### Changes
+
+- Use Bytes as default type, if meta or type wasn't specified.
+- Handle error in `program.metaHex` method
+
 ## 0.30.1
 
 _03/10/2023_

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -5,7 +5,13 @@ import { randomAsHex } from '@polkadot/util-crypto';
 
 import { IProgram, OldMetadata, ProgramMap } from './types/interfaces';
 import { IProgramCreateOptions, IProgramCreateResult, IProgramUploadOptions, IProgramUploadResult } from './types';
-import { ProgramDoesNotExistError, ProgramExitedError, ProgramTerminatedError, SubmitProgramError } from './errors';
+import {
+  ProgramDoesNotExistError,
+  ProgramExitedError,
+  ProgramHasNoMetahash,
+  ProgramTerminatedError,
+  SubmitProgramError,
+} from './errors';
 import { ProgramMetadata, isProgramMeta } from './metadata';
 import { generateCodeHash, generateProgramId, getIdsFromKeys, validateGasLimit, validateValue } from './utils';
 import { GearApi } from './GearApi';
@@ -217,7 +223,7 @@ export class GearProgram extends GearTransaction {
   async codeHash(id: HexString): Promise<HexString> {
     const programOption = (await this._api.query.gearProgram.programStorage(id)) as Option<ProgramMap>;
 
-    if (programOption.isNone) throw new ProgramDoesNotExistError();
+    if (programOption.isNone) throw new ProgramDoesNotExistError(id);
 
     const program = programOption.unwrap()[0];
 
@@ -235,7 +241,19 @@ export class GearProgram extends GearTransaction {
    * @returns
    */
   async metaHash(programId: HexString, at?: HexString): Promise<HexString> {
-    const metaHash = (await this._api.rpc['gear'].readMetahash(programId, at || null)) as H256;
-    return metaHash.toHex();
+    try {
+      const metaHash = (await this._api.rpc['gear'].readMetahash(programId, at || null)) as H256;
+      return metaHash.toHex();
+    } catch (error) {
+      if (error.code === 8000) {
+        if (error.data.includes('Program not found')) {
+          throw new ProgramDoesNotExistError(programId);
+        }
+        if (error.data.includes('unreachable')) {
+          throw new ProgramHasNoMetahash(programId);
+        }
+      }
+      throw error;
+    }
   }
 }

--- a/api/src/Storage.ts
+++ b/api/src/Storage.ts
@@ -18,7 +18,7 @@ export class GearProgramStorage {
     const programOption = (await this._api.query.gearProgram.programStorage(programId)) as Option<ProgramMap>;
 
     if (programOption.isNone) {
-      throw new ProgramDoesNotExistError();
+      throw new ProgramDoesNotExistError(programId);
     }
 
     const program = programOption.unwrap()[0];

--- a/api/src/errors/program.errors.ts
+++ b/api/src/errors/program.errors.ts
@@ -9,8 +9,8 @@ export class SubmitProgramError extends Error {
 export class ProgramDoesNotExistError extends Error {
   name = 'ProgramDoesNotExist';
 
-  constructor() {
-    super('Program does not exist');
+  constructor(id: string) {
+    super(`Program with id ${id} does not exist`);
   }
 }
 
@@ -40,8 +40,16 @@ export class ProgramExitedError extends Error {
 
 export class CodeDoesNotExistError extends Error {
   name = 'CodeDoesNotExist';
-  
+
   constructor(id: string) {
     super(`Code with id ${id} not found in the storage`);
+  }
+}
+
+export class ProgramHasNoMetahash extends Error {
+  name = 'ProgramHasNoMetahash';
+
+  constructor(id: string) {
+    super(`Program with id ${id} has not metahash function`);
   }
 }

--- a/api/src/utils/create-payload.ts
+++ b/api/src/utils/create-payload.ts
@@ -51,7 +51,8 @@ export function encodePayload<
         )
         .toU8a(),
     );
-  } else if (isOldMeta(hexRegistryOrMeta)) {
+  }
+  if (isOldMeta(hexRegistryOrMeta)) {
     return Array.from(
       CreateType.create(
         isString(typeIndexOrMessageType) ? typeIndexOrMessageType : hexRegistryOrMeta[type as keyof OldMetadata],
@@ -59,11 +60,13 @@ export function encodePayload<
         hexRegistryOrMeta.types,
       ).toU8a(),
     );
-  } else if (isHex(hexRegistryOrMeta)) {
+  }
+  if (isHex(hexRegistryOrMeta)) {
     if (typeof typeIndexOrMessageType === 'number') {
       return Array.from(new GearMetadata(hexRegistryOrMeta).createType(typeIndexOrMessageType, payload).toU8a());
     } else {
       return Array.from(CreateType.create(typeIndexOrMessageType, payload, hexRegistryOrMeta).toU8a());
     }
   }
+  return Array.from(CreateType.create('Bytes', payload).toU8a());
 }


### PR DESCRIPTION
### Changes

- Use Bytes as default type, if meta or type wasn't specified.
- Handle error in `program.metaHex` method
---
### Bump version to `0.30.2`