### PR TITLE
Fix the problem of inconsistency between sendMessage parameters and t…

### DIFF
--- a/api/src/Message.ts
+++ b/api/src/Message.ts
@@ -117,7 +117,7 @@ export class GearMessage extends GearTransaction {
     const _payload = encodePayload(payload, metaOrHexRegistry, 'handle', typeIndexOrTypeName);
 
     try {
-      this.extrinsic = this._api.tx.gear.sendMessage(destination, _payload, gasLimit, value || 0, prepaid || false);
+      this.extrinsic = this._api.tx.gear.sendMessage(destination, _payload, gasLimit, value || 0);
       return this.extrinsic;
     } catch (error) {
       throw new SendMessageError(error.message);


### PR DESCRIPTION
…he chain

Resolves # .
When using gear sdk, I encountered the following error:
<img width="764" alt="image" src="https://github.com/gear-tech/gear-js/assets/31732456/1da67d38-0406-4c16-935a-5ba2d2d61937">

After research, I found out that the sendmessage of gear.js has one more prepaid parameter than the chain：
<img width="1759" alt="image" src="https://github.com/gear-tech/gear-js/assets/31732456/aa48ae2f-a76c-4ff6-8845-c1f8783d0689">
<img width="904" alt="image" src="https://github.com/gear-tech/gear-js/assets/31732456/93350db4-65b1-4058-86f8-f070329e2002">

Therefore, I deleted the parameter prepaid of the sendmessage function of the gear.js sdk to ensure that the interface on the chain is consistent with that of the gear.js sdk to solve this problem.


@reviewer-or-team
