### PR TITLE
[gear-idea] Reduce the speed of program messages requests

### DIFF
--- a/idea/common/src/interfaces/rpc-request/indexer.ts
+++ b/idea/common/src/interfaces/rpc-request/indexer.ts
@@ -5,7 +5,7 @@ import { IPaginationParams } from '../pagination';
 import { IProgram } from '../program';
 import { IState } from '../state';
 
-export interface GetMessagesParams extends IGenesis, IPaginationParams, SearchParam, IDates {
+export interface GetMessagesParams extends IGenesis, IPaginationParams,  IDates {
   destination?: string;
   source?: string;
   mailbox?: boolean;

--- a/idea/frontend/src/widgets/programMessages/ui/ProgramMessages.tsx
+++ b/idea/frontend/src/widgets/programMessages/ui/ProgramMessages.tsx
@@ -15,7 +15,8 @@ type Props = {
 };
 
 type RequestParams = {
-  query: HexString;
+  source: HexString;
+  destination: HexString;
 };
 
 const ProgramMessages = ({ programId }: Props) => {
@@ -24,7 +25,7 @@ const ProgramMessages = ({ programId }: Props) => {
   const [activeFilter, setActiveFilter] = useState(MessageFilter.Messages);
 
   const { loadData } = useDataLoading<RequestParams>({
-    defaultParams: { query: programId },
+    defaultParams: { source: programId, destination: programId },
     fetchData: fetchMessages,
   });
 

--- a/idea/indexer/src/gear/indexer.ts
+++ b/idea/indexer/src/gear/indexer.ts
@@ -686,8 +686,12 @@ export class GearIndexer {
   private async getProgram(id: HexString, blockHash: HexString, msgId: HexString): Promise<Program> {
     let program = await this.tempState.getProgram(id);
     if (!program) {
-      logger.error(`Unable to retrieve program by id ${id} for message ${msgId} encountered in block ${blockHash}`);
-      program = await this.indexBlockWithMissedProgram(id);
+      logger.error('Failed to retrieve program', { id, blockHash, msgId } );
+      try{
+        program = await this.indexBlockWithMissedProgram(id);
+      } catch(err){
+        logger.error('Failed to index block', { method: 'getProgram', blockHash, program: id, msg: msgId });    
+      } 
     }
     return program;
   }

--- a/idea/tests/e2e/indexer.test.ts
+++ b/idea/tests/e2e/indexer.test.ts
@@ -640,9 +640,9 @@ describe('message methods', () => {
 
   test(INDEXER_METHODS.MESSAGE_ALL + ' by program', async () => {
     const response = await request('message.all', { genesis, source: testMetaId, destination: testMetaId });
-    expect(response).toHaveProperty('result.count', 8);
+    expect(response).toHaveProperty('result.count', 11);
     expect(response).toHaveProperty('result.messages');
-    expect(response.result.messages).toHaveLength(8);
+    expect(response.result.messages).toHaveLength(11);
   });
 
   test(INDEXER_METHODS.MESSAGE_DATA, async () => {

--- a/idea/tests/e2e/indexer.test.ts
+++ b/idea/tests/e2e/indexer.test.ts
@@ -638,6 +638,13 @@ describe('message methods', () => {
     expect(response.result.messages).toHaveLength(sentMessages.length + receivedMessages.length);
   });
 
+  test(INDEXER_METHODS.MESSAGE_ALL + ' by program', async () => {
+    const response = await request('message.all', { genesis, source: testMetaId, destination: testMetaId });
+    expect(response).toHaveProperty('result.count', 8);
+    expect(response).toHaveProperty('result.messages');
+    expect(response.result.messages).toHaveLength(8);
+  });
+
   test(INDEXER_METHODS.MESSAGE_DATA, async () => {
     for (const m of sentMessages) {
       const response = await request('message.data', { genesis, id: m.id });


### PR DESCRIPTION
- `query` parameter has been removed from `message.all` request. It will significantly reduce the request time.
- The `source` and `destination parameters can be used to request all program messages.