### PR TITLE
Support `gearVoucher.call` tx and keepAlive parameter in gear txs

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ https://github.com/gear-tech/gear-js/pull/1436
 - Support `gearVoucher.call` extrinsic according to https://github.com/gear-tech/gear/pull/3401
 - Support `keepAlive` field in `sendMessage`, `sendReply`, `uploadProgram` and `createProgram` extrinsics accoriding to https://github.com/gear-tech/gear/pull/3425
 - Bump `polkadot-js` version to 10.10.1
+- Support different APIs for Vara and Vara Testnet Network
 
 ## 0.34.0
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.35.0
+
+_09/29/2023_
+
+### Changes
+https://github.com/gear-tech/gear-js/pull/1436
+- Support `gearVoucher.call` extrinsic according to https://github.com/gear-tech/gear/pull/3401
+- Support `keepAlive` field in `sendMessage`, `sendReply`, `uploadProgram` and `createProgram` extrinsics accoriding to https://github.com/gear-tech/gear/pull/3425
+- Bump `polkadot-js` version to 10.10.1
+
 ## 0.34.0
 
 _09/29/2023_

--- a/api/README.md
+++ b/api/README.md
@@ -51,6 +51,7 @@ const nodeVersion = await gearApi.nodeVersion();
 const genesis = gearApi.genesisHash.toHex();
 ```
 
+Since Vara and VaraTestnet can have different runtime versions, they can have different extrinsics signatures. If your application is running on the Vara Network it is more convinient to use the `VaraApi` class instead of `GearApi` and `VaraTestnetApi` for the Vara Testnet Network
 ---
 
 ## Payloads and metadata

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/programs/Cargo.lock
+++ b/api/programs/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -78,9 +78,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -124,9 +124,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camino"
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -292,7 +292,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -303,23 +303,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -401,7 +390,7 @@ dependencies = [
 [[package]]
 name = "galloc"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "dlmalloc",
 ]
@@ -409,7 +398,7 @@ dependencies = [
 [[package]]
 name = "gcore"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "gear-core-errors",
  "gear-stack-buffer",
@@ -421,7 +410,7 @@ dependencies = [
 [[package]]
 name = "gear-core"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -432,6 +421,7 @@ dependencies = [
  "hashbrown",
  "hex",
  "log",
+ "num-traits",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -442,7 +432,7 @@ dependencies = [
 [[package]]
 name = "gear-core-errors"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "derive_more",
  "enum-iterator",
@@ -452,7 +442,7 @@ dependencies = [
 [[package]]
 name = "gear-stack-buffer"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 
 [[package]]
 name = "gear-wasm"
@@ -463,7 +453,7 @@ checksum = "f745ed9eb163f4509f01d5564e37db52ec43dd23569bafdba597a5f1e4c125c9"
 [[package]]
 name = "gear-wasm-builder"
 version = "0.1.2"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -487,7 +477,7 @@ dependencies = [
 [[package]]
 name = "gear-wasm-instrument"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "enum-iterator",
  "gwasm-instrument",
@@ -507,7 +497,7 @@ dependencies = [
 [[package]]
 name = "gmeta"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "blake2-rfc",
  "derive_more",
@@ -519,17 +509,17 @@ dependencies = [
 [[package]]
 name = "gmeta-codegen"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "gstd"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "bs58",
  "futures",
@@ -548,17 +538,17 @@ dependencies = [
 [[package]]
 name = "gstd-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "gsys"
 version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#1feb3d25e5bcd5077bd83b64079053655d4d6bce"
+source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
 
 [[package]]
 name = "gwasm-instrument"
@@ -571,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -602,16 +592,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -645,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -693,9 +683,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libc-print"
@@ -708,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -720,9 +710,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "nodrop"
@@ -732,9 +722,9 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -813,9 +803,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -835,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -890,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -902,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -913,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustc_version"
@@ -928,11 +918,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -947,9 +937,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -959,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -971,31 +961,31 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1043,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1135,22 +1125,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1238,7 +1228,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -1260,7 +1250,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1315,10 +1305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets",
 ]
@@ -1391,9 +1381,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
 ]

--- a/api/programs/Cargo.lock
+++ b/api/programs/Cargo.lock
@@ -4,13 +4,14 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -106,9 +107,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -389,16 +393,16 @@ dependencies = [
 
 [[package]]
 name = "galloc"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "dlmalloc",
 ]
 
 [[package]]
 name = "gcore"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "gear-core-errors",
  "gear-stack-buffer",
@@ -409,8 +413,8 @@ dependencies = [
 
 [[package]]
 name = "gear-core"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "blake2-rfc",
  "byteorder",
@@ -418,6 +422,7 @@ dependencies = [
  "enum-iterator",
  "gear-core-errors",
  "gear-wasm-instrument",
+ "gsys",
  "hashbrown",
  "hex",
  "log",
@@ -431,8 +436,8 @@ dependencies = [
 
 [[package]]
 name = "gear-core-errors"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "derive_more",
  "enum-iterator",
@@ -441,8 +446,8 @@ dependencies = [
 
 [[package]]
 name = "gear-stack-buffer"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 
 [[package]]
 name = "gear-wasm"
@@ -453,7 +458,7 @@ checksum = "f745ed9eb163f4509f01d5564e37db52ec43dd23569bafdba597a5f1e4c125c9"
 [[package]]
 name = "gear-wasm-builder"
 version = "0.1.2"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -476,8 +481,8 @@ dependencies = [
 
 [[package]]
 name = "gear-wasm-instrument"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "enum-iterator",
  "gwasm-instrument",
@@ -496,8 +501,8 @@ dependencies = [
 
 [[package]]
 name = "gmeta"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "blake2-rfc",
  "derive_more",
@@ -508,8 +513,8 @@ dependencies = [
 
 [[package]]
 name = "gmeta-codegen"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -518,8 +523,8 @@ dependencies = [
 
 [[package]]
 name = "gstd"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "bs58",
  "futures",
@@ -538,7 +543,7 @@ dependencies = [
 [[package]]
 name = "gstd-codegen"
 version = "0.1.0"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -547,8 +552,8 @@ dependencies = [
 
 [[package]]
 name = "gsys"
-version = "1.0.1"
-source = "git+https://github.com/gear-tech/gear.git#ece52b485e55b4d62f76dca0ee4ea38f0504243f"
+version = "1.0.2"
+source = "git+https://github.com/gear-tech/gear.git#a721177f3a1761dcba90b98a703619521c50e78d"
 
 [[package]]
 name = "gwasm-instrument"
@@ -1001,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1144,6 +1149,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -1395,4 +1415,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]

--- a/api/programs/rust-toolchain.toml
+++ b/api/programs/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-04-25"
+channel = "nightly-2023-10-14"
 components = [ "llvm-tools" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -48,9 +48,14 @@ export class GearApi extends ApiPromise {
       rpc: {
         ...gearRpc,
       },
-      // it's temporarily necessary to avoid the warning "API/INIT: Not decorating unknown runtime apis: GearApi/1"
       runtime: {
         GearApi: [
+          {
+            methods: {},
+            version: 2,
+          },
+        ],
+        Vara: [
           {
             methods: {},
             version: 1,

--- a/api/src/Message.ts
+++ b/api/src/Message.ts
@@ -14,7 +14,7 @@ import { encodePayload, getExtrinsic, validateGasLimit, validateMailboxItem, val
 import { GearTransaction } from './Transaction';
 import { ProgramMetadata } from './metadata';
 import { UserMessageSentData } from './events';
-import { VARA_GENESIS } from 'specs';
+import { VARA_GENESIS } from './specs';
 
 export class GearMessage extends GearTransaction {
   /**

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -11,12 +11,15 @@ import {
   IProgramCreateResult,
   IProgramUploadOptions,
   IProgramUploadResult,
+  VaraProgramCreateOptions,
+  VaraProgramUploadOptions,
 } from './types';
 import { ProgramDoesNotExistError, ProgramHasNoMetahash, SubmitProgramError } from './errors';
 import {
   encodePayload,
   generateCodeHash,
   generateProgramId,
+  getExtrinsic,
   getIdsFromKeys,
   validateGasLimit,
   validateProgramId,
@@ -27,6 +30,7 @@ import { GearGas } from './Gas';
 import { GearResumeSession } from './ResumeSession';
 import { GearTransaction } from './Transaction';
 import { ProgramMetadata } from './metadata';
+import { VARA_GENESIS } from 'specs';
 
 export class GearProgram extends GearTransaction {
   public calculateGas: GearGas;
@@ -60,7 +64,11 @@ export class GearProgram extends GearTransaction {
    * })
    * ```
    */
-  upload(args: IProgramUploadOptions, meta?: ProgramMetadata, typeIndex?: number): IProgramUploadResult;
+  upload(
+    args: IProgramUploadOptions | VaraProgramUploadOptions,
+    meta?: ProgramMetadata,
+    typeIndex?: number,
+  ): IProgramUploadResult;
 
   /**
    * ### Upload program with code using registry in hex format to encode payload
@@ -69,7 +77,11 @@ export class GearProgram extends GearTransaction {
    * @param typeIndex Index of type in the registry.
    * @returns Object containing program id, generated (or specified) salt, code id, prepared extrinsic
    */
-  upload(args: IProgramUploadOptions, hexRegistry: HexString, typeIndex: number): IProgramUploadResult;
+  upload(
+    args: IProgramUploadOptions | VaraProgramUploadOptions,
+    hexRegistry: HexString,
+    typeIndex: number,
+  ): IProgramUploadResult;
 
   /** ### Upload program with code using type name to encode payload
    * @param args
@@ -77,13 +89,13 @@ export class GearProgram extends GearTransaction {
    * @param typeName type name (one of the default rust types if metadata or registry don't specified)
    */
   upload(
-    args: IProgramUploadOptions,
+    args: IProgramUploadOptions | VaraProgramUploadOptions,
     metaOrHexRegistry?: ProgramMetadata | HexString,
     typeName?: string,
   ): IProgramUploadResult;
 
   upload(
-    args: IProgramUploadOptions,
+    args: IProgramUploadOptions | VaraProgramUploadOptions,
     metaOrHexRegistry?: ProgramMetadata | HexString,
     typeIndexOrTypeName?: number | string,
   ): IProgramUploadResult {
@@ -98,14 +110,13 @@ export class GearProgram extends GearTransaction {
     const programId = generateProgramId(this._api, codeId, salt);
 
     try {
-      this.extrinsic = this._api.tx.gear.uploadProgram(
-        code,
-        salt,
-        payload,
-        args.gasLimit,
-        args.value || 0,
-        args.keepAlive || true,
-      );
+      const txArgs: any[] = [code, salt, payload, args.gasLimit, args.value || 0];
+      if (this._api.genesisHash.eq(VARA_GENESIS)) {
+        txArgs.push('keepAlive' in args ? args.keepAlive : true);
+      }
+
+      this.extrinsic = getExtrinsic(this._api, 'gear', 'uploadProgram', txArgs);
+
       return { programId, codeId, salt, extrinsic: this.extrinsic };
     } catch (error) {
       throw new SubmitProgramError();
@@ -134,7 +145,11 @@ export class GearProgram extends GearTransaction {
    * })
    * ```
    */
-  create(args: IProgramCreateOptions, meta?: ProgramMetadata, typeIndex?: number | null): IProgramCreateResult;
+  create(
+    args: IProgramCreateOptions | VaraProgramCreateOptions,
+    meta?: ProgramMetadata,
+    typeIndex?: number | null,
+  ): IProgramCreateResult;
 
   /**
    * ### Create program from uploaded on chain code using program metadata to encode payload
@@ -143,7 +158,11 @@ export class GearProgram extends GearTransaction {
    * @param typeIndex Index of type in the registry.
    * @returns Object containing program id, generated (or specified) salt, prepared extrinsic
    */
-  create(args: IProgramCreateOptions, hexRegistry: HexString, typeIndex: number): IProgramCreateResult;
+  create(
+    args: IProgramCreateOptions | VaraProgramCreateOptions,
+    hexRegistry: HexString,
+    typeIndex: number,
+  ): IProgramCreateResult;
 
   /** ## Create program using existed codeId
    * @param args
@@ -151,13 +170,13 @@ export class GearProgram extends GearTransaction {
    * @param type name type name (one of the default rust types if metadata or registry don't specified)
    */
   create(
-    args: IProgramCreateOptions,
+    args: IProgramCreateOptions | VaraProgramCreateOptions,
     metaOrHexRegistry?: HexString | ProgramMetadata,
     typeName?: number | string,
   ): IProgramCreateResult;
 
   create(
-    { codeId, initPayload, value, gasLimit, ...args }: IProgramCreateOptions,
+    { codeId, initPayload, value, gasLimit, ...args }: IProgramCreateOptions | VaraProgramCreateOptions,
     metaOrHexRegistry?: HexString | ProgramMetadata,
     typeIndexOrTypeName?: number | string | null,
   ): IProgramCreateResult {
@@ -170,14 +189,14 @@ export class GearProgram extends GearTransaction {
     const programId = generateProgramId(this._api, codeId, salt);
 
     try {
-      this.extrinsic = this._api.tx.gear.createProgram(
-        codeId,
-        salt,
-        payload,
-        gasLimit,
-        value || 0,
-        args.keepAlive || true,
-      );
+      const txArgs: any[] = [codeId, salt, payload, gasLimit, value || 0];
+
+      if (this._api.genesisHash.eq(VARA_GENESIS)) {
+        txArgs.push('keepAlive' in args ? args.keepAlive : true);
+      }
+
+      this.extrinsic = getExtrinsic(this._api, 'gear', 'createProgram', txArgs);
+
       return { programId, salt, extrinsic: this.extrinsic };
     } catch (error) {
       throw new SubmitProgramError();

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -30,7 +30,7 @@ import { GearGas } from './Gas';
 import { GearResumeSession } from './ResumeSession';
 import { GearTransaction } from './Transaction';
 import { ProgramMetadata } from './metadata';
-import { VARA_GENESIS } from 'specs';
+import { VARA_GENESIS } from './specs';
 
 export class GearProgram extends GearTransaction {
   public calculateGas: GearGas;
@@ -111,7 +111,7 @@ export class GearProgram extends GearTransaction {
 
     try {
       const txArgs: any[] = [code, salt, payload, args.gasLimit, args.value || 0];
-      if (this._api.genesisHash.eq(VARA_GENESIS)) {
+      if (!this._api.genesisHash.eq(VARA_GENESIS)) {
         txArgs.push('keepAlive' in args ? args.keepAlive : true);
       }
 
@@ -119,6 +119,7 @@ export class GearProgram extends GearTransaction {
 
       return { programId, codeId, salt, extrinsic: this.extrinsic };
     } catch (error) {
+      console.log(error);
       throw new SubmitProgramError();
     }
   }
@@ -191,7 +192,7 @@ export class GearProgram extends GearTransaction {
     try {
       const txArgs: any[] = [codeId, salt, payload, gasLimit, value || 0];
 
-      if (this._api.genesisHash.eq(VARA_GENESIS)) {
+      if (!this._api.genesisHash.eq(VARA_GENESIS)) {
         txArgs.push('keepAlive' in args ? args.keepAlive : true);
       }
 

--- a/api/src/Program.ts
+++ b/api/src/Program.ts
@@ -98,7 +98,14 @@ export class GearProgram extends GearTransaction {
     const programId = generateProgramId(this._api, codeId, salt);
 
     try {
-      this.extrinsic = this._api.tx.gear.uploadProgram(code, salt, payload, args.gasLimit, args.value || 0);
+      this.extrinsic = this._api.tx.gear.uploadProgram(
+        code,
+        salt,
+        payload,
+        args.gasLimit,
+        args.value || 0,
+        args.keepAlive || true,
+      );
       return { programId, codeId, salt, extrinsic: this.extrinsic };
     } catch (error) {
       throw new SubmitProgramError();
@@ -163,7 +170,14 @@ export class GearProgram extends GearTransaction {
     const programId = generateProgramId(this._api, codeId, salt);
 
     try {
-      this.extrinsic = this._api.tx.gear.createProgram(codeId, salt, payload, gasLimit, value || 0);
+      this.extrinsic = this._api.tx.gear.createProgram(
+        codeId,
+        salt,
+        payload,
+        gasLimit,
+        value || 0,
+        args.keepAlive || true,
+      );
       return { programId, salt, extrinsic: this.extrinsic };
     } catch (error) {
       throw new SubmitProgramError();

--- a/api/src/apis/index.ts
+++ b/api/src/apis/index.ts
@@ -1,0 +1,2 @@
+export { VaraApi } from './vara/api';
+export { VaraTestnetApi } from './vara-testnet/api';

--- a/api/src/apis/vara-testnet/api.ts
+++ b/api/src/apis/vara-testnet/api.ts
@@ -1,0 +1,3 @@
+import { GearApi } from '../../GearApi';
+
+export class VaraTestnetApi extends GearApi {}

--- a/api/src/apis/vara/api.ts
+++ b/api/src/apis/vara/api.ts
@@ -1,0 +1,8 @@
+import { GearApi } from '../../GearApi';
+import { VaraMessage } from './message';
+import { VaraProgram } from './program';
+
+export class VaraApi extends GearApi {
+  public declare program: VaraProgram;
+  public declare message: VaraMessage;
+}

--- a/api/src/apis/vara/message.ts
+++ b/api/src/apis/vara/message.ts
@@ -1,0 +1,40 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+
+import { VaraMessageSendOptions, VaraMessageSendReplyOptions } from '../../types';
+import { GearMessage } from '../../Message';
+import { ProgramMetadata } from '../../metadata';
+
+export declare class VaraMessage extends GearMessage {
+  send(
+    args: VaraMessageSendOptions,
+    meta: ProgramMetadata,
+    typeIndex?: number,
+  ): SubmittableExtrinsic<'promise', ISubmittableResult>;
+  send(
+    args: VaraMessageSendOptions,
+    hexRegistry: `0x${string}`,
+    typeIndex: number,
+  ): SubmittableExtrinsic<'promise', ISubmittableResult>;
+  send(
+    args: VaraMessageSendOptions,
+    metaOrHexRegistry?: ProgramMetadata | `0x${string}`,
+    typeName?: string,
+  ): SubmittableExtrinsic<'promise', ISubmittableResult>;
+
+  sendReply(
+    args: VaraMessageSendReplyOptions,
+    meta?: ProgramMetadata,
+    typeIndex?: number,
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
+  sendReply(
+    args: VaraMessageSendReplyOptions,
+    hexRegistry: `0x${string}`,
+    typeIndex: number,
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
+  sendReply(
+    args: VaraMessageSendReplyOptions,
+    metaOrHexRegistry?: ProgramMetadata | `0x${string}`,
+    typeName?: string,
+  ): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>>;
+}

--- a/api/src/apis/vara/program.ts
+++ b/api/src/apis/vara/program.ts
@@ -1,0 +1,29 @@
+import {
+  HexString,
+  IProgramCreateResult,
+  IProgramUploadResult,
+  VaraProgramCreateOptions,
+  VaraProgramUploadOptions,
+} from '../../types';
+import { GearProgram } from '../../Program';
+import { ProgramMetadata } from '../../metadata';
+
+export declare class VaraProgram extends GearProgram {
+  upload(args: VaraProgramUploadOptions, meta?: ProgramMetadata, typeIndex?: number): IProgramUploadResult;
+
+  upload(args: VaraProgramUploadOptions, hexRegistry: HexString, typeIndex: number): IProgramUploadResult;
+
+  upload(
+    args: VaraProgramUploadOptions,
+    metaOrHexRegistry?: ProgramMetadata | HexString,
+    typeName?: string,
+  ): IProgramUploadResult;
+
+  create(args: VaraProgramCreateOptions, meta?: ProgramMetadata, typeIndex?: number): IProgramCreateResult;
+  create(args: VaraProgramCreateOptions, hexRegistry: `0x${string}`, typeIndex: number): IProgramCreateResult;
+  create(
+    args: VaraProgramCreateOptions,
+    metaOrHexRegistry?: ProgramMetadata | `0x${string}`,
+    typeName?: string | number,
+  ): IProgramCreateResult;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -20,3 +20,4 @@ export * from './events';
 export * from './types';
 export * from './metadata';
 export * from './apis';
+export * from './specs';

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,3 +19,4 @@ export * from './utils';
 export * from './events';
 export * from './types';
 export * from './metadata';
+export * from './apis';

--- a/api/src/types/augment/augment-api-tx.ts
+++ b/api/src/types/augment/augment-api-tx.ts
@@ -3,7 +3,7 @@ import '@polkadot/api-base/types/submittable';
 import type { AnyNumber, ITuple } from '@polkadot/types-codec/types';
 import type { ApiTypes, AugmentedSubmittable } from '@polkadot/api-base/types';
 import type { BTreeSet, Bytes, Option, Vec, bool, u128, u32, u64 } from '@polkadot/types-codec';
-import { GearCoreIdsCodeId, GearCoreIdsMessageId, GearCoreIdsProgramId } from '../lookup';
+import { GearCoreIdsCodeId, GearCoreIdsMessageId, GearCoreIdsProgramId, PalletGearVoucherPrepaidCall } from '../lookup';
 import type { MultiAddress } from '@polkadot/types/interfaces/runtime';
 
 declare module '@polkadot/api-base/types/submittable' {
@@ -48,6 +48,7 @@ declare module '@polkadot/api-base/types/submittable' {
           initPayload: Bytes | string | Uint8Array | number[],
           gasLimit: u64 | AnyNumber | Uint8Array,
           value: u128 | AnyNumber | Uint8Array,
+          keepAlive: bool | boolean | Uint8Array,
         ) => SubmittableExtrinsic<ApiType>,
         [GearCoreIdsCodeId, Bytes, Bytes, u64, u128]
       >;
@@ -131,18 +132,11 @@ declare module '@polkadot/api-base/types/submittable' {
        * is not a program in uninitialized state. If the opposite holds true,
        * the message is not enqueued for processing.
        *
-       * If `prepaid` flag is set, the transaction fee and the gas cost will be
-       * charged against a `voucher` that must have been issued for the sender
-       * in conjunction with the `destination` program. That means that the
-       * synthetic account corresponding to the (`AccountId`, `ProgramId`) pair must
-       * exist and have sufficient funds in it. Otherwise, the call is invalidated.
-       *
        * Parameters:
        * - `destination`: the message destination.
        * - `payload`: in case of a program destination, parameters of the `handle` function.
        * - `gas_limit`: maximum amount of gas the program can spend before it is halted.
        * - `value`: balance to be transferred to the program once it's been created.
-       * - `prepaid`: a flag that indicates whether a voucher should be used.
        *
        * Emits the following events:
        * - `DispatchMessageEnqueued(MessageInfo)` when dispatch message is placed in the queue.
@@ -153,7 +147,7 @@ declare module '@polkadot/api-base/types/submittable' {
           payload: Bytes | string | Uint8Array | number[],
           gasLimit: u64 | AnyNumber | Uint8Array,
           value: u128 | AnyNumber | Uint8Array,
-          prepaid: bool | boolean | Uint8Array,
+          keepAlive: bool | boolean | Uint8Array,
         ) => SubmittableExtrinsic<ApiType>,
         [GearCoreIdsProgramId, Bytes, u64, u128, bool]
       >;
@@ -171,12 +165,6 @@ declare module '@polkadot/api-base/types/submittable' {
        *
        * NOTE: only user who is destination of the message, can claim value
        * or reply on the message from mailbox.
-       *
-       * If `prepaid` flag is set, the transaction fee and the gas cost will be
-       * charged against a `voucher` that must have been issued for the sender
-       * in conjunction with the mailboxed message source program. That means that the
-       * synthetic account corresponding to the (`AccountId`, `ProgramId`) pair must
-       * exist and have sufficient funds in it. Otherwise, the call is invalidated.
        **/
       sendReply: AugmentedSubmittable<
         (
@@ -184,7 +172,7 @@ declare module '@polkadot/api-base/types/submittable' {
           payload: Bytes | string | Uint8Array | number[],
           gasLimit: u64 | AnyNumber | Uint8Array,
           value: u128 | AnyNumber | Uint8Array,
-          prepaid: bool | boolean | Uint8Array,
+          keepAlive: bool | boolean | Uint8Array,
         ) => SubmittableExtrinsic<ApiType>,
         [GearCoreIdsMessageId, Bytes, u64, u128, bool]
       >;
@@ -263,6 +251,7 @@ declare module '@polkadot/api-base/types/submittable' {
           initPayload: Bytes | string | Uint8Array | number[],
           gasLimit: u64 | AnyNumber | Uint8Array,
           value: u128 | AnyNumber | Uint8Array,
+          keepAlive: bool | boolean | Uint8Array,
         ) => SubmittableExtrinsic<ApiType>,
         [Bytes, Bytes, Bytes, u64, u128]
       >;
@@ -272,6 +261,15 @@ declare module '@polkadot/api-base/types/submittable' {
       [key: string]: SubmittableExtrinsicFunction<ApiType>;
     };
     gearVoucher: {
+      /**
+       * Dispatch allowed with voucher call.
+       **/
+      call: AugmentedSubmittable<
+        (
+          call: PalletGearVoucherPrepaidCall | { SendMessage: any } | { SendReply: any } | string | Uint8Array,
+        ) => SubmittableExtrinsic<ApiType>,
+        [PalletGearVoucherPrepaidCall]
+      >;
       /**
        * Issue a new voucher for a `user` to be used to pay for sending messages
        * to `program_id` program.

--- a/api/src/types/interfaces/index.ts
+++ b/api/src/types/interfaces/index.ts
@@ -6,3 +6,4 @@ export * from './gas';
 export * from './api-options';
 export * from './keyring';
 export * from './metadata';
+export * from './voucher';

--- a/api/src/types/interfaces/message/extrinsic.ts
+++ b/api/src/types/interfaces/message/extrinsic.ts
@@ -36,3 +36,17 @@ export interface IMessageSendReplyOptions extends Omit<IMessageSendOptions, 'des
    */
   replyToId: HexString;
 }
+
+export interface VaraMessageSendOptions extends Omit<IMessageSendOptions, 'keepAlive'> {
+  /**
+   * A flag that indicates whether a voucher should be used
+   */
+  prepaid?: boolean;
+}
+
+export interface VaraMessageSendReplyOptions extends Omit<IMessageSendReplyOptions, 'keepAlive'> {
+  /**
+   * Message ID to which the reply is sending
+   */
+  replyToId: HexString;
+}

--- a/api/src/types/interfaces/message/extrinsic.ts
+++ b/api/src/types/interfaces/message/extrinsic.ts
@@ -21,9 +21,9 @@ export interface IMessageSendOptions {
    */
   value?: Value;
   /**
-   * A flag that indicates whether a voucher should be used.
+   * A flag that indicates whether the account should be kept alive after the value is sent to the program.
    */
-  prepaid?: boolean;
+  keepAlive?: boolean;
   /**
    * ID of the account sending the message
    */

--- a/api/src/types/interfaces/program/extrinsic.ts
+++ b/api/src/types/interfaces/program/extrinsic.ts
@@ -19,6 +19,12 @@ export interface IProgramCreateOptions extends Omit<IProgramUploadOptions, 'code
   codeId: HexString | Uint8Array;
 }
 
+export type VaraProgramUploadOptions = Omit<IProgramUploadOptions, 'keepAlive'>;
+
+export interface VaraProgramCreateOptions extends Omit<VaraProgramUploadOptions, 'code'> {
+  codeId: HexString | Uint8Array;
+}
+
 export interface IProgramUploadResult {
   programId: HexString;
   codeId: HexString;

--- a/api/src/types/interfaces/program/extrinsic.ts
+++ b/api/src/types/interfaces/program/extrinsic.ts
@@ -12,6 +12,7 @@ export interface IProgramUploadOptions {
   initPayload?: AnyJson;
   gasLimit: GasLimit;
   value?: Value;
+  keepAlive?: boolean;
 }
 
 export interface IProgramCreateOptions extends Omit<IProgramUploadOptions, 'code'> {

--- a/api/src/types/interfaces/voucher.ts
+++ b/api/src/types/interfaces/voucher.ts
@@ -1,0 +1,6 @@
+import { ISubmittableResult } from '@polkadot/types/types';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+
+export type ICallOptions =
+  | { SendMessage: SubmittableExtrinsic<'promise', ISubmittableResult> }
+  | { SendReply: SubmittableExtrinsic<'promise', ISubmittableResult> };

--- a/api/src/types/lookup.ts
+++ b/api/src/types/lookup.ts
@@ -444,6 +444,25 @@ export interface FrameSupportDispatchRawOrigin extends Enum {
   readonly type: 'Root' | 'Signed' | 'None';
 }
 
+/** @name PalletGearVoucherPrepaidCall (280) */
+export interface PalletGearVoucherPrepaidCall extends Enum {
+  readonly isSendMessage: boolean;
+  readonly asSendMessage: {
+    readonly destination: GearCoreIdsProgramId;
+    readonly payload: Bytes;
+    readonly gasLimit: u64;
+    readonly value: u128;
+  } & Struct;
+  readonly isSendReply: boolean;
+  readonly asSendReply: {
+    readonly replyToId: GearCoreIdsMessageId;
+    readonly payload: Bytes;
+    readonly gasLimit: u64;
+    readonly value: u128;
+  } & Struct;
+  readonly type: 'SendMessage' | 'SendReply';
+}
+
 /** @name GearCoreCodeInstrumentedCode (217) */
 export interface GearCoreCodeInstrumentedCode extends Struct {
   readonly code: Bytes;

--- a/api/src/utils/getExtrinsic.ts
+++ b/api/src/utils/getExtrinsic.ts
@@ -1,0 +1,5 @@
+import { GearApi } from 'GearApi';
+
+export function getExtrinsic(api: GearApi, section: string, method: string, args: any[]) {
+  return api.tx[section][method](...args);
+}

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from './address';
 export * from './signature';
 export * from './regexp';
 export * from './create-payload';
+export * from './getExtrinsic';

--- a/api/test/ExtrinsicError.test.ts
+++ b/api/test/ExtrinsicError.test.ts
@@ -20,7 +20,7 @@ afterAll(async () => {
 
 describe('Get extrinsic errors', () => {
   test('send incorrect transaction', async () => {
-    const submitted = api.tx.gear.uploadProgram('0x123456', '0x123', '0x00', 1000, 0);
+    const submitted = api.tx.gear.uploadProgram('0x123456', '0x123', '0x00', 1000, 0, true);
     const error: RegistryError = await new Promise((resolve) => {
       submitted.signAndSend(alice, ({ events = [] }) => {
         events.forEach(({ event }) => {

--- a/api/test/Message.test.ts
+++ b/api/test/Message.test.ts
@@ -56,12 +56,13 @@ describe('Gear Message', () => {
     ];
 
     for (const message of messages) {
-      const tx = await api.message.send(
+      const tx = api.message.send(
         {
           destination: programId,
           payload: message.payload,
           gasLimit: 20_000_000_000,
           value: message.value,
+          keepAlive: true,
         },
         metadata,
       );

--- a/api/test/Transfer.test.ts
+++ b/api/test/Transfer.test.ts
@@ -16,14 +16,8 @@ afterAll(async () => {
   await sleep(1000);
 });
 
-describe('Subscribe to balance transfer events', () => {
+describe('Transfer balance', () => {
   test('Transfer balance', async () => {
-    const subsribeTransfer = new Promise((resolve) => {
-      api.gearEvents.subscribeToTransferEvents((event) => {
-        resolve(event.data);
-      });
-    });
-
     api.balance.transfer(bob.address, 10000);
 
     const transferData: TransferData = await new Promise((resolve, reject) => {
@@ -40,10 +34,5 @@ describe('Subscribe to balance transfer events', () => {
     expect(transferData).toHaveProperty('from');
     expect(transferData).toHaveProperty('to');
     expect(transferData).toHaveProperty('amount');
-
-    const subsribeTransferData = (await subsribeTransfer) as TransferData;
-    expect(transferData.from.toHex()).toBe(subsribeTransferData.from.toHex());
-    expect(transferData.to.toHex()).toBe(subsribeTransferData.to.toHex());
-    expect(transferData['amount'].toHex()).toBe(subsribeTransferData['amount'].toHex());
   });
 });

--- a/api/test/Voucher.test.ts
+++ b/api/test/Voucher.test.ts
@@ -78,12 +78,11 @@ describe('Voucher', () => {
         },
         gasLimit: 20_000_000_000,
         account: charlieRaw,
-        prepaid: true,
       },
       metadata,
     );
 
-    const [txData] = await sendTransaction(tx, charlie, ['MessageQueued']);
+    const [txData] = await sendTransaction(api.voucher.call({ SendMessage: tx }), charlie, ['MessageQueued']);
     expect(txData).toBeDefined();
     expect(txData.id).toBeDefined();
     msgId = txData.id.toHex();
@@ -104,7 +103,6 @@ describe('Voucher', () => {
         gasLimit: 20_000_000_000,
         value: 0,
         payload: 'Charlie',
-        prepaid: true,
       },
       metadata,
       metadata.types.reply!,
@@ -112,7 +110,7 @@ describe('Voucher', () => {
 
     const waitForReply = api.message.listenToReplies(programId);
 
-    const [txData] = await sendTransaction(tx, charlie, ['MessageQueued']);
+    const [txData] = await sendTransaction(api.voucher.call({ SendReply: tx }), charlie, ['MessageQueued']);
     expect(txData).toBeDefined();
 
     const reply = await waitForReply(msgId);


### PR DESCRIPTION
## Changes
- Support `gearVoucher.call` extrinsic according to https://github.com/gear-tech/gear/pull/3401
- Support `keepAlive` field in `sendMessage`, `sendReply`, `uploadProgram` and `createProgram` extrinsics accoriding to https://github.com/gear-tech/gear/pull/3425
- Bump `polkadot-js` version to 10.10.1
---
### Bump version to `0.35.0`