### PR TITLE
Fix `api.getExtrinsicFailed` method

### DIFF
--- a/.github/workflows/CI-CD-gear-js-api.yml
+++ b/.github/workflows/CI-CD-gear-js-api.yml
@@ -81,8 +81,8 @@ jobs:
         run: |          
           nohup ./gear --dev --execution=wasm --tmp --unsafe-ws-external --unsafe-rpc-external --rpc-methods Unsafe --rpc-cors all &
 
-      - name: "Prepare: sleep 10 seconds"
-        run: sleep 10
+      - name: "Prepare: sleep 3 min"
+        run: sleep 180
 
       - name: "Test: run"
         working-directory: api

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,9 @@ _11/07/2023_
 https://github.com/gear-tech/gear-js/pull/1447
 - Read storage of memory pages according to https://github.com/gear-tech/gear/pull/3166
 
+https://github.com/gear-tech/gear-js/pull/1451
+- Fix `api.getExtrinsicFailedError` method. It now returns an object with the formatted docs, method and name of the error
+
 ## 0.35.2
 
 _10/31/2023_

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -157,13 +157,15 @@ export class GearApi extends ApiPromise {
         method: data?.method,
         name: data?.name,
       };
-    } else if (error.isCannotLookup) {
+    }
+    if (error.isCannotLookup) {
       return {
         docs: null,
         method: 'CannotLookup',
         name: 'CannotLookup',
       };
-    } else if (error.isBadOrigin) {
+    }
+    if (error.isBadOrigin) {
       return {
         docs: null,
         method: 'BadOrigin',

--- a/api/src/GearApi.ts
+++ b/api/src/GearApi.ts
@@ -1,9 +1,8 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { DispatchError, Event } from '@polkadot/types/interfaces';
 import { u128, u64 } from '@polkadot/types';
-import { RegistryError } from '@polkadot/types-codec/types';
 
-import { GearApiOptions, GearCommonGasMultiplier, InflationInfo } from './types';
+import { ExtrinsicFailedData, GearApiOptions, GearCommonGasMultiplier, InflationInfo } from './types';
 import { gearRpc, gearTypes } from './default';
 import { GearBalance } from './Balance';
 import { GearBlock } from './Blocks';
@@ -149,9 +148,33 @@ export class GearApi extends ApiPromise {
    * @param event
    * @returns
    */
-  getExtrinsicFailedError(event: Event): RegistryError {
+  getExtrinsicFailedError(event: Event): ExtrinsicFailedData {
     const error = event.data[0] as DispatchError;
-    const { isModule, asModule } = error;
-    return isModule ? this.registry.findMetaError(asModule) : null;
+    if (error.isModule) {
+      const data = this.registry.findMetaError(error.asModule);
+      return {
+        docs: data?.docs.join(' '),
+        method: data?.method,
+        name: data?.name,
+      };
+    } else if (error.isCannotLookup) {
+      return {
+        docs: null,
+        method: 'CannotLookup',
+        name: 'CannotLookup',
+      };
+    } else if (error.isBadOrigin) {
+      return {
+        docs: null,
+        method: 'BadOrigin',
+        name: 'BadOrigin',
+      };
+    }
+
+    return {
+      docs: null,
+      method: 'Unknown error',
+      name: 'Unknown error',
+    };
   }
 }

--- a/api/src/types/interfaces/extrinsic-failed.ts
+++ b/api/src/types/interfaces/extrinsic-failed.ts
@@ -1,0 +1,5 @@
+export interface ExtrinsicFailedData {
+  docs: string;
+  method: string;
+  name: string;
+}

--- a/api/src/types/interfaces/index.ts
+++ b/api/src/types/interfaces/index.ts
@@ -7,3 +7,4 @@ export * from './api-options';
 export * from './keyring';
 export * from './metadata';
 export * from './voucher';
+export * from './extrinsic-failed';

--- a/api/test/ExtrinsicError.test.ts
+++ b/api/test/ExtrinsicError.test.ts
@@ -1,8 +1,7 @@
 import { KeyringPair } from '@polkadot/keyring/types';
-import { RegistryError } from '@polkadot/types-codec/types';
 
+import { ExtrinsicFailedData, GearApi } from '../src';
 import { getAccount, sleep } from './utilsFunctions';
-import { GearApi } from '../src';
 import { WS_ADDRESS } from './config';
 
 const api = new GearApi({ providerAddress: WS_ADDRESS });
@@ -21,7 +20,7 @@ afterAll(async () => {
 describe('Get extrinsic errors', () => {
   test('send incorrect transaction', async () => {
     const submitted = api.tx.gear.uploadProgram('0x123456', '0x123', '0x00', 1000, 0, true);
-    const error: RegistryError = await new Promise((resolve) => {
+    const error = await new Promise<ExtrinsicFailedData>((resolve) => {
       submitted.signAndSend(alice, ({ events = [] }) => {
         events.forEach(({ event }) => {
           if (api.events.system.ExtrinsicFailed.is(event)) {
@@ -30,7 +29,7 @@ describe('Get extrinsic errors', () => {
         });
       });
     });
-    expect(error.docs.join(' ')).toBe('Failed to create a program.');
+    expect(error.docs).toBe('Failed to create a program.');
     expect(error.method).toBe('ProgramConstructionFailed');
     expect(error.name).toBe('ProgramConstructionFailed');
   });


### PR DESCRIPTION
## Changes
- Fix `api.getExtrinsicFailedError` method. It now returns an object with the formatted docs, method and name of the error