### PR TITLE
[api] Release `0.36.0`

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,12 +1,13 @@
-## master
+## 0.36.0
 
-_11/07/2023_
+_01/23/2024_
 
 ### Changes
 https://github.com/gear-tech/gear-js/pull/1447
 - Read storage of memory pages according to https://github.com/gear-tech/gear/pull/3166
 
 https://github.com/gear-tech/gear-js/pull/1451
+<i><b>Breaking changes</b></i>
 - Fix `api.getExtrinsicFailedError` method. It now returns an object with the formatted docs, method and name of the error
 
 https://github.com/gear-tech/gear-js/pull/1467
@@ -14,7 +15,7 @@ https://github.com/gear-tech/gear-js/pull/1467
 - Bump polkadot dependencies to `10.11.2`
 
 https://github.com/gear-tech/gear-js/pull/1472
-- Support `uploadCode` call for vouchers.
+- Support `uploadCode` call for vouchers according to https://github.com/gear-tech/gear/pull/3672.
 
 ## 0.35.2
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/src/Storage.ts
+++ b/api/src/Storage.ts
@@ -49,11 +49,11 @@ export class GearProgramStorage {
   async getProgramPages(programId: HexString, program: GearCommonActiveProgram, at?: HexString): Promise<IGearPages> {
     const pages = {};
     const query =
-      this._api.specVersion >= SPEC_VERSION.V1050
+      this._api.specVersion >= SPEC_VERSION.V1100
         ? this._api.query.gearProgram.memoryPages
         : this._api.query.gearProgram.memoryPageStorage;
 
-    const args = this._api.specVersion >= SPEC_VERSION.V1050 ? [programId, program.memoryInfix] : [programId];
+    const args = this._api.specVersion >= SPEC_VERSION.V1100 ? [programId, program.memoryInfix] : [programId];
 
     for (const page of program.pagesWithData) {
       pages[page.toNumber()] = u8aToU8a(

--- a/api/src/Voucher.ts
+++ b/api/src/Voucher.ts
@@ -53,7 +53,7 @@ export class GearVoucher extends GearTransaction {
   }
 
   /**
-   * Issue a new voucher. This method is available only for runtime versions < 1050.
+   * Issue a new voucher. This method is available only for runtime versions < 1100.
    * @deprecated
    * @param to
    * @param program
@@ -125,7 +125,7 @@ export class GearVoucher extends GearTransaction {
   }
 
   /**
-   * Use a voucher to send a message to a program. This method is available only for runtime versions < 1050.
+   * Use a voucher to send a message to a program. This method is available only for runtime versions < 1100.
    * @deprecated
    * @param params
    * @returns

--- a/api/src/consts.ts
+++ b/api/src/consts.ts
@@ -1,5 +1,5 @@
 export enum SPEC_VERSION {
   V1000 = 1000,
   V1010 = 1010,
-  V1050 = 1050,
+  V1100 = 1100,
 }


### PR DESCRIPTION
### Changes
https://github.com/gear-tech/gear-js/pull/1447
- Read storage of memory pages.

https://github.com/gear-tech/gear-js/pull/1451
<i><b>Breaking changes</b></i>
- Fix `api.getExtrinsicFailedError` method. It now returns an object with the formatted docs, method and name of the error

https://github.com/gear-tech/gear-js/pull/1467
- Support new vouchers.
- Bump polkadot dependencies to `10.11.2`

https://github.com/gear-tech/gear-js/pull/1472
- Support `uploadCode` call for vouchers.