### PR TITLE
feat(api): subscribe to events only on finalized blocks

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.37.1
+
+_04/10/2024_
+
+### Changes
+https://github.com/gear-tech/gear-js/pull/1522
+- Subsribe to gear events only on finalized blocks
+
 ## 0.37.0
 
 _03/12/2024_

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",


### PR DESCRIPTION
### Changes

- Subscribe to gear events only on finalized blocks
---
### Bump version to `0.37.1`