### PR TITLE
fix(api): remove `balances.transfer` method

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.38.0
+
+_04/26/2024_
+
+### Changes
+https://github.com/gear-tech/gear-js/pull/1538
+- Remove `balances.transfer` method
+- `api.balance.transfer` method now accepts one more argument `keepAlive` that is set to `true` by default
+
 ## 0.37.2
 
 _04/11/2024_

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
   },
   "license": "GPL-3.0",
   "peerDependencies": {
-    "@polkadot/api": "10.12.3",
+    "@polkadot/api": "11.0.2",
     "@polkadot/wasm-crypto": "7.3.2",
     "rxjs": "7.8.1"
   },

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gear-js/api",
-  "version": "0.37.2",
+  "version": "0.38.0",
   "description": "A JavaScript library that provides functionality to connect GEAR Component APIs.",
   "main": "cjs/index.js",
   "module": "index.js",

--- a/api/src/Balance.ts
+++ b/api/src/Balance.ts
@@ -12,8 +12,12 @@ export class GearBalance extends GearTransaction {
     return this._api.createType('Balance', balance.free) as Balance;
   }
 
-  transfer(to: string, value: number | BN): SubmittableExtrinsic<'promise', ISubmittableResult> {
-    this.extrinsic = this._api.tx.balances.transfer(to, value);
+  transfer(
+    to: string,
+    value: number | BN,
+    keepAlive = true,
+  ): SubmittableExtrinsic<'promise', ISubmittableResult> {
+    this.extrinsic = this._api.tx.balances[keepAlive ? 'transferKeepAlive' : 'transferAllowDeath'](to, value);
     return this.extrinsic;
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1568,7 +1568,7 @@ __metadata:
     ts-node: 10.9.2
     typescript: 5.4.2
   peerDependencies:
-    "@polkadot/api": 10.12.3
+    "@polkadot/api": 11.0.2
     "@polkadot/wasm-crypto": 7.3.2
     rxjs: 7.8.1
   languageName: unknown


### PR DESCRIPTION
### Changes
- Remove `balances.transfer` method
- `api.balance.transfer` method now accepts one more argument `keepAlive` that is set to `true` by default
---
### Bump version to `0.38.0`