### PR TITLE
refactor(idea/frontend): upload program/code `signAndSend`

### DIFF
--- a/idea/frontend/src/api/program/requests.ts
+++ b/idea/frontend/src/api/program/requests.ts
@@ -8,8 +8,8 @@ import { FetchProgramsParams, ProgramPaginationModel } from './types';
 
 const fetchProgram = (id: string) => rpcService.callRPC<IProgram>(RpcMethods.GetProgram, { id });
 
-const addProgramName = (params: { id: HexString; name: string }, isDevChain: boolean | undefined) =>
-  isDevChain ? Promise.resolve() : rpcService.callRPC(RpcMethods.AddProgramName, params);
+const addProgramName = (params: { id: HexString; name: string }) =>
+  rpcService.callRPC(RpcMethods.AddProgramName, params);
 
 const fetchPrograms = (params: FetchProgramsParams) =>
   rpcService.callRPC<ProgramPaginationModel>(RpcMethods.GetAllPrograms, params);

--- a/idea/frontend/src/hooks/use-contract-api-with-file.ts
+++ b/idea/frontend/src/hooks/use-contract-api-with-file.ts
@@ -52,7 +52,7 @@ function useContractApiWithFile(codeIdOrBuffer: HexString | Buffer | undefined) 
 
     if (extension === FILE_EXTENSION.IDL) {
       metadata.reset();
-      await sails.set(text);
+      sails.set(text);
     }
   };
 

--- a/idea/frontend/src/hooks/use-sign-and-send.tsx
+++ b/idea/frontend/src/hooks/use-sign-and-send.tsx
@@ -12,12 +12,14 @@ type Options = {
   onSuccess: () => void;
   onError: () => void;
   onFinally: () => void;
+  onFinalized: (value: ISubmittableResult) => void;
 };
 
-const DEFAULT_OPTIONS: Options = {
+const DEFAULT_OPTIONS = {
   onSuccess: () => {},
   onError: () => {},
   onFinally: () => {},
+  onFinalized: () => {},
 } as const;
 
 function useSignAndSend() {
@@ -46,9 +48,10 @@ function useSignAndSend() {
     }
   };
 
-  const handleStatus = ({ events, status }: ISubmittableResult, method: string, options: Options, alertId: string) => {
+  const handleStatus = (result: ISubmittableResult, method: string, options: Options, alertId: string) => {
+    const { events, status } = result;
     const { isInvalid, isReady, isInBlock, isFinalized } = status;
-    const { onError, onFinally } = options;
+    const { onError, onFinally, onFinalized } = options;
 
     if (isInvalid) {
       alert.update(alertId, 'Transaction error. Status: isInvalid', DEFAULT_ERROR_OPTIONS);
@@ -63,6 +66,8 @@ function useSignAndSend() {
 
     if (isFinalized) {
       alert.update(alertId, 'Finalized', DEFAULT_SUCCESS_OPTIONS);
+
+      onFinalized(result);
 
       events.forEach(({ event }) => handleEvent(event, method, options));
     }

--- a/idea/frontend/src/hooks/use-sign-and-send.tsx
+++ b/idea/frontend/src/hooks/use-sign-and-send.tsx
@@ -3,12 +3,14 @@ import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { Event } from '@polkadot/types/interfaces';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { web3FromSource } from '@polkadot/extension-dapp';
+import { ReactNode } from 'react';
 
 import { useExtrinsicFailedMessage } from './use-extrinsic-failed-message';
 
 type Extrinsic = SubmittableExtrinsic<'promise', ISubmittableResult>;
 
 type Options = {
+  successAlert: ReactNode;
   onSuccess: () => void;
   onError: () => void;
   onFinally: () => void;
@@ -16,6 +18,7 @@ type Options = {
 };
 
 const DEFAULT_OPTIONS = {
+  successAlert: 'Success',
   onSuccess: () => {},
   onError: () => {},
   onFinally: () => {},
@@ -28,7 +31,7 @@ function useSignAndSend() {
   const getExtrinsicFailedMessage = useExtrinsicFailedMessage();
 
   const handleEvent = (event: Event, method: string, options: Options) => {
-    const { onSuccess, onError, onFinally } = options;
+    const { successAlert, onSuccess, onError, onFinally } = options;
     const alertOptions = { title: `${event.section}.${event.method}` };
 
     if (event.method === 'ExtrinsicFailed') {
@@ -41,7 +44,7 @@ function useSignAndSend() {
     }
 
     if (event.method === method) {
-      alert.success('Success', alertOptions);
+      alert.success(successAlert, alertOptions);
 
       onSuccess();
       onFinally();

--- a/idea/frontend/src/hooks/useCodeUpload/types.ts
+++ b/idea/frontend/src/hooks/useCodeUpload/types.ts
@@ -1,8 +1,4 @@
 import { HexString } from '@polkadot/util/types';
-import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { ISubmittableResult } from '@polkadot/types/types';
-
-import { ParamsToSignAndSend as CommonParamsToSignAndSend } from '@/entities/hooks';
 
 type ParamsToUploadCode = {
   optBuffer: Buffer;
@@ -13,12 +9,4 @@ type ParamsToUploadCode = {
   resolve: () => void;
 };
 
-type ParamsToSignAndSend = Omit<CommonParamsToSignAndSend, 'reject'> & {
-  extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>;
-  name: string;
-  codeId: HexString;
-  metaHex: HexString | undefined;
-  idl: string | undefined;
-};
-
-export type { ParamsToUploadCode, ParamsToSignAndSend };
+export type { ParamsToUploadCode };

--- a/idea/frontend/src/hooks/useProgramActions/consts.ts
+++ b/idea/frontend/src/hooks/useProgramActions/consts.ts
@@ -1,7 +1,0 @@
-import { AlertOptions } from '@gear-js/react-hooks';
-
-const ALERT_OPTIONS: AlertOptions = {
-  title: 'Program initialization',
-};
-
-export { ALERT_OPTIONS };

--- a/idea/frontend/src/hooks/useProgramActions/types.ts
+++ b/idea/frontend/src/hooks/useProgramActions/types.ts
@@ -1,8 +1,6 @@
 import { ProgramMetadata } from '@gear-js/api';
 import { HexString } from '@polkadot/util/types';
 
-import { OperationCallbacks, ParamsToSignAndSend } from '@/entities/hooks';
-
 type Payload = {
   value: string;
   gasLimit: string;
@@ -15,25 +13,4 @@ type Payload = {
   idl?: string;
 };
 
-type DataToUpload = {
-  optBuffer: Buffer;
-  payload: Payload;
-};
-
-type DataToCreate = {
-  codeId: HexString;
-  payload: Payload;
-};
-
-type ParamsToUpload = OperationCallbacks & DataToUpload;
-
-type ParamsToCreate = OperationCallbacks & DataToCreate;
-
-type ParamsToSignAndUpload = ParamsToSignAndSend & {
-  method: string;
-  payload: Payload;
-  programId: HexString;
-  codeId: HexString;
-};
-
-export type { Payload, ParamsToUpload, ParamsToCreate, ParamsToSignAndUpload };
+export type { Payload };

--- a/idea/frontend/src/hooks/useProgramActions/useProgramActions.tsx
+++ b/idea/frontend/src/hooks/useProgramActions/useProgramActions.tsx
@@ -1,23 +1,13 @@
-import { useCallback } from 'react';
 import { generatePath } from 'react-router-dom';
-import { EventRecord } from '@polkadot/types/interfaces';
+import { useApi, useAccount, useAlert } from '@gear-js/react-hooks';
+import { HexString, IProgramCreateResult, IProgramUploadResult, ProgramMetadata } from '@gear-js/api';
 import { web3FromSource } from '@polkadot/extension-dapp';
-import { useApi, useAccount, useAlert, DEFAULT_ERROR_OPTIONS, DEFAULT_SUCCESS_OPTIONS } from '@gear-js/react-hooks';
-import { HexString } from '@polkadot/util/types';
-import { ProgramMetadata } from '@gear-js/api';
+import { ISubmittableResult } from '@polkadot/types/types';
 
-import { useChain, useModal } from '@/hooks';
+import { useChain, useModal, useSignAndSend } from '@/hooks';
 import { uploadLocalProgram } from '@/api/LocalDB';
-import { Method } from '@/features/explorer';
-import { OperationCallbacks } from '@/entities/hooks';
-import {
-  PROGRAM_ERRORS,
-  TransactionName,
-  TransactionStatus,
-  absoluteRoutes,
-  UPLOAD_METADATA_TIMEOUT,
-} from '@/shared/config';
-import { checkWallet, getExtrinsicFailedMessage, isNullOrUndefined } from '@/shared/helpers';
+import { absoluteRoutes, UPLOAD_METADATA_TIMEOUT } from '@/shared/config';
+import { isNullOrUndefined } from '@/shared/helpers';
 import { CustomLink } from '@/shared/ui/customLink';
 import { ProgramStatus, useProgramStatus } from '@/features/program';
 import { isHumanTypesRepr } from '@/features/metadata';
@@ -25,14 +15,14 @@ import { addProgramName } from '@/api';
 import { addIdl } from '@/features/sails';
 
 import { useMetadataUpload } from '../useMetadataUpload';
-import { ALERT_OPTIONS } from './consts';
-import { Payload, ParamsToCreate, ParamsToUpload, ParamsToSignAndUpload } from './types';
+import { Payload } from './types';
 
 const useProgramActions = () => {
   const alert = useAlert();
   const { api, isApiReady } = useApi();
   const { account } = useAccount();
   const { isDevChain } = useChain();
+  const signAndSend = useSignAndSend();
 
   const { showModal } = useModal();
   const { getProgramStatus } = useProgramStatus();
@@ -44,214 +34,87 @@ const useProgramActions = () => {
     </p>
   );
 
-  const createProgram = (codeId: HexString, payload: Payload) => {
+  // will be refactored in the upcoming local indexer refactoring
+  const handleMetadataUpload = async (
+    programId: HexString,
+    codeId: HexString,
+    payload: Payload,
+    result: ISubmittableResult,
+  ) => {
+    const { programName, metaHex, idl } = payload;
+    const name = programName || programId;
+
+    // timeout cuz wanna be sure that block data is ready
+    setTimeout(async () => {
+      await addProgramName({ id: programId, name }, isDevChain);
+
+      if (metaHex) uploadMetadata({ codeHash: codeId, metaHex, programId });
+      if (idl) addIdl(codeId, idl);
+    }, UPLOAD_METADATA_TIMEOUT);
+
+    const programMessage = getProgramMessage(programId);
+    const programStatus = await getProgramStatus(programId);
+
+    if (programStatus === ProgramStatus.Terminated) {
+      alert.error(programMessage, { title: 'Program is terminated' });
+    }
+
+    if (programStatus === ProgramStatus.Exited) {
+      alert.error(programMessage, { title: 'Program is exited' });
+    }
+    if (programStatus === ProgramStatus.Active) {
+      alert.success(programMessage, { title: 'Program is active' });
+    }
+
+    if (!isDevChain) return;
     if (!isApiReady) throw new Error('API is not initialized');
+    if (!account) throw new Error('Account not found');
 
-    const { gasLimit, value, initPayload, metadata, payloadType, keepAlive } = payload;
+    const metahash = await api.code.metaHash(codeId);
+    const meta = metaHex ? ProgramMetadata.from(metaHex) : undefined;
 
-    const program = { value, codeId, gasLimit, initPayload, keepAlive };
+    const hasState =
+      !!meta &&
+      (typeof meta.types.state === 'number' ||
+        (isHumanTypesRepr(meta.types.state) && !isNullOrUndefined(meta.types.state.output)));
 
-    const result = api.program.create(program, metadata, payloadType);
-
-    return result.programId;
-  };
-
-  const uploadProgram = (optBuffer: Buffer, payload: Payload) => {
-    if (!isApiReady) throw new Error('API is not initialized');
-
-    const { gasLimit, value, initPayload, metadata, payloadType, keepAlive } = payload;
-
-    const program = { code: optBuffer, value, gasLimit, initPayload, keepAlive };
-
-    return api.program.upload(program, metadata, payloadType);
-  };
-
-  const handleEventsStatus = (events: EventRecord[], { reject }: OperationCallbacks) => {
-    if (!isApiReady) throw new Error('API is not initialized');
-
-    events.forEach(({ event }) => {
-      const { method, section } = event;
-      const alertOptions = { title: `${section}.${method}` };
-
-      if (method === Method.ExtrinsicFailed) {
-        alert.error(getExtrinsicFailedMessage(api, event), alertOptions);
-
-        if (reject) reject();
-      }
+    uploadLocalProgram({
+      id: programId,
+      owner: account.decodedAddress,
+      code: { id: codeId },
+      status: programStatus,
+      blockHash: result.status.asFinalized.toHex(),
+      hasState,
+      metahash,
+      name,
     });
   };
 
-  const signAndUpload = async ({
-    signer,
-    payload,
-    programId,
-    codeId,
-    reject,
-    resolve,
-    method,
-  }: ParamsToSignAndUpload) => {
-    const { metaHex, programName, idl } = payload;
-    const alertId = alert.loading('SignIn', { title: method });
-    const programMessage = getProgramMessage(programId);
-    const name = programName || programId;
+  return async (
+    { programId, extrinsic }: IProgramCreateResult | IProgramUploadResult,
+    codeId: HexString,
+    payload: Payload,
+    onSuccess?: () => void,
+    onError?: () => void,
+  ) => {
+    if (!isApiReady) throw new Error('API is not initialized');
+    if (!account) throw new Error('Account not found');
 
-    try {
-      if (!isApiReady) throw new Error('API is not initialized');
+    const { meta, address } = account;
+    const { signer } = await web3FromSource(meta.source);
+    const { partialFee } = await api.program.paymentInfo(address, { signer });
 
-      await api.program.signAndSend(account!.address, { signer }, ({ status, events }) => {
-        if (status.isReady) {
-          alert.update(alertId, TransactionStatus.Ready);
-        } else if (status.isInBlock) {
-          alert.update(alertId, TransactionStatus.InBlock);
-        } else if (status.isFinalized) {
-          alert.update(alertId, TransactionStatus.Finalized, DEFAULT_SUCCESS_OPTIONS);
-          handleEventsStatus(events, { reject, resolve });
+    const onFinalized = (result: ISubmittableResult) => handleMetadataUpload(programId, codeId, payload, result);
+    const onConfirm = () => signAndSend(extrinsic, 'ProgramChanged', { onSuccess, onError, onFinalized });
 
-          // timeout cuz wanna be sure that block data is ready
-          setTimeout(() => {
-            addProgramName({ id: programId, name }, isDevChain).then(() => {
-              // TODO: no need to upload if meta/idl is from storage
-              if (metaHex) uploadMetadata({ codeHash: codeId, metaHex, programId });
-              if (idl) addIdl(codeId, idl);
-            });
-          }, UPLOAD_METADATA_TIMEOUT);
-
-          getProgramStatus(programId).then(async (programStatus) => {
-            if ([ProgramStatus.Terminated, ProgramStatus.Exited].includes(programStatus)) {
-              alert.error(programMessage, ALERT_OPTIONS);
-
-              if (reject) reject();
-            } else {
-              alert.success(programMessage, ALERT_OPTIONS);
-
-              if (resolve) resolve();
-            }
-
-            if (isDevChain) {
-              const metahash = await api.code.metaHash(codeId);
-              const meta = metaHex ? ProgramMetadata.from(metaHex) : undefined;
-
-              const hasState =
-                !!meta &&
-                (typeof meta.types.state === 'number' ||
-                  (isHumanTypesRepr(meta.types.state) && !isNullOrUndefined(meta.types.state.output)));
-
-              await uploadLocalProgram({
-                id: programId,
-                owner: account!.decodedAddress,
-                code: { id: codeId },
-                status: programStatus,
-                blockHash: status.asFinalized.toHex(),
-                hasState,
-                metahash,
-                name,
-              });
-            }
-          });
-        } else if (status.isInvalid) {
-          alert.update(alertId, PROGRAM_ERRORS.INVALID_TRANSACTION, DEFAULT_ERROR_OPTIONS);
-
-          if (reject) reject();
-        }
-      });
-    } catch (error) {
-      const message = (error as Error).message;
-
-      alert.update(alertId, message, DEFAULT_ERROR_OPTIONS);
-
-      if (reject) reject();
-    }
+    showModal('transaction', {
+      fee: partialFee.toHuman(),
+      name: `${extrinsic.method.section}.${extrinsic.method.method}`,
+      addressFrom: address,
+      onAbort: onError,
+      onConfirm,
+    });
   };
-
-  const create = useCallback(
-    async ({ codeId, payload, reject, resolve }: ParamsToCreate) => {
-      try {
-        if (!isApiReady) throw new Error('API is not initialized');
-        checkWallet(account);
-
-        const { meta, address } = account!;
-
-        const [{ signer }, programId] = await Promise.all([
-          web3FromSource(meta.source),
-          createProgram(codeId, payload),
-        ]);
-
-        const { partialFee } = await api.program.paymentInfo(address, { signer });
-
-        const handleConfirm = () =>
-          signAndUpload({
-            method: TransactionName.CreateProgram,
-            signer,
-            payload,
-            programId,
-            codeId,
-            reject,
-            resolve,
-          });
-
-        showModal('transaction', {
-          fee: partialFee.toHuman(),
-          name: TransactionName.CreateProgram,
-          addressFrom: address,
-          onAbort: reject,
-          onConfirm: handleConfirm,
-        });
-      } catch (error) {
-        const message = (error as Error).message;
-
-        alert.error(message);
-        if (reject) reject();
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [api, account, uploadMetadata],
-  );
-
-  const upload = useCallback(
-    async ({ optBuffer, payload, reject, resolve }: ParamsToUpload) => {
-      try {
-        if (!isApiReady) throw new Error('API is not initialized');
-        checkWallet(account);
-
-        const { meta, address } = account!;
-
-        const [{ signer }, { programId, codeId }] = await Promise.all([
-          web3FromSource(meta.source),
-          uploadProgram(optBuffer, payload),
-        ]);
-
-        const { partialFee } = await api.program.paymentInfo(address, { signer });
-
-        const handleConfirm = () =>
-          signAndUpload({
-            method: TransactionName.UploadProgram,
-            signer,
-            payload,
-            programId,
-            codeId,
-            reject,
-            resolve,
-          });
-
-        showModal('transaction', {
-          fee: partialFee.toHuman(),
-          name: TransactionName.UploadProgram,
-          addressFrom: address,
-          onAbort: reject,
-          onConfirm: handleConfirm,
-        });
-      } catch (error) {
-        const message = (error as Error).message;
-
-        alert.error(message);
-        if (reject) reject();
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [api, account, uploadMetadata],
-  );
-
-  return { uploadProgram: upload, createProgram: create };
 };
 
 export { useProgramActions };

--- a/idea/frontend/src/widgets/uploadMetadataModal/ui/UploadMetadataModal.tsx
+++ b/idea/frontend/src/widgets/uploadMetadataModal/ui/UploadMetadataModal.tsx
@@ -50,7 +50,7 @@ const UploadMetadataModal = ({ codeId, programId, onClose, onSuccess }: Props) =
 
     try {
       if (programId) {
-        await addProgramName({ name, id: programId }, isDevChain);
+        if (!isDevChain) await addProgramName({ name, id: programId });
       } else {
         await addCodeName({ name, id: codeId });
       }


### PR DESCRIPTION
Necessary improvements in order to start refactoring storage for local nodes.

Re-using `useSignAndSend` hook to drop repetitive logic and separate upload metadata side-effects.