### PR TITLE
refactor(squid) split state handler into routers

### DIFF
--- a/idea/squid/src/call.route.ts
+++ b/idea/squid/src/call.route.ts
@@ -1,0 +1,61 @@
+import { generateCodeHash } from '@gear-js/api';
+import { MessageToProgram, Program } from './model';
+
+import { IHandleEventProps } from './event.route';
+import { Call } from './processor';
+
+export interface IHandleCallProps extends IHandleEventProps {
+  msg: MessageToProgram;
+  call: Call;
+}
+
+export function handleUploadProgram({ msg, event, common, tempState, call }: IHandleCallProps) {
+  const codeId = generateCodeHash(call.args.code);
+  tempState.addProgram(
+    new Program({
+      ...common,
+      id: event.args.destination,
+      codeId,
+      owner: event.args.source,
+      name: event.args.destination,
+    }),
+  );
+  msg.payload = call.args.initPayload;
+  msg.value = call.args.value;
+}
+
+export function handleSendMessageCall({ msg, call }: IHandleCallProps) {
+  msg.payload = call.args.payload;
+  msg.value = call.args.value;
+}
+
+export function handleVoucherCall({ ctx, msg, call }: IHandleCallProps) {
+  if (call.args.call.__kind === 'SendMessage') {
+    msg.payload = call.args.call.payload;
+    msg.value = call.args.call.value;
+  } else if (call.args.call.__kind === 'SendReply') {
+    msg.payload = call.args.call.payload;
+    msg.replyToMessageId = call.args.call.replyToId;
+    msg.value = call.args.call.value;
+  } else {
+    ctx.log.error(call, 'Unkown voucher call');
+  }
+}
+
+export function handleCreateProgram({ event, common, tempState, call }: IHandleCallProps) {
+  tempState.addProgram(
+    new Program({
+      ...common,
+      id: event.args.destination,
+      codeId: call.args.codeId,
+      owner: event.args.source,
+      name: event.args.destination,
+    }),
+  );
+}
+
+export function handleSendReplyCall({ msg, call }: IHandleCallProps) {
+  msg.payload = call.args.payload;
+  msg.value = call.args.value;
+  msg.replyToMessageId = call.args.replyToId;
+}

--- a/idea/squid/src/call.route.ts
+++ b/idea/squid/src/call.route.ts
@@ -38,7 +38,7 @@ export function handleVoucherCall({ ctx, msg, call }: IHandleCallProps) {
     msg.replyToMessageId = call.args.call.replyToId;
     msg.value = call.args.call.value;
   } else {
-    ctx.log.error(call, 'Unkown voucher call');
+    ctx.log.error(call, 'Unknown voucher call');
   }
 }
 

--- a/idea/squid/src/event.route.ts
+++ b/idea/squid/src/event.route.ts
@@ -1,0 +1,160 @@
+import { Store } from '@subsquid/typeorm-store';
+import { Block } from '@subsquid/substrate-processor';
+import { ZERO_ADDRESS } from 'sails-js';
+import { Code, MessageEntryPoint, MessageFromProgram, MessageToProgram, MetaType, Program } from './model';
+
+import { Event, Fields, ProcessorContext } from './processor';
+import { TempState } from './temp-state';
+import { isCreateProgram, isUploadCode, isUploadProgram } from './types/calls';
+import { isSendMessageCall, isSendReplyCall } from './types/calls/message';
+import { isVoucherCall } from './types/calls/voucher';
+import { CodeStatus, MessageReadReason, ProgramStatus } from './model';
+import { getMetahash } from './util';
+import {
+  IHandleCallProps,
+  handleCreateProgram,
+  handleSendMessageCall,
+  handleSendReplyCall,
+  handleUploadProgram,
+  handleVoucherCall,
+} from './call.route';
+
+export interface IHandleEventProps {
+  ctx: ProcessorContext<Store>;
+  event: Event;
+  common: {
+    timestamp: Date;
+    blockHash: string;
+    blockNumber: string;
+  };
+  tempState: TempState;
+  block: Block<Fields>;
+}
+
+const callHandlers: Array<{ pattern: (obj: any) => boolean; handler: (args: IHandleCallProps) => void }> = [
+  { pattern: isUploadProgram, handler: handleUploadProgram },
+  { pattern: isSendMessageCall, handler: handleSendMessageCall },
+  { pattern: isVoucherCall, handler: handleVoucherCall },
+  { pattern: isCreateProgram, handler: handleCreateProgram },
+  { pattern: isSendReplyCall, handler: handleSendReplyCall },
+];
+
+export async function handleMessageQueued({ ctx, block, event, common, tempState }: IHandleEventProps) {
+  const call = event.call;
+
+  const msg = new MessageToProgram({
+    ...common,
+    id: event.args.id,
+    source: event.args.source,
+    destination: event.args.destination,
+    entry: event.args.entry.__kind.toLowerCase() as MessageEntryPoint,
+  });
+
+  const { handler } = callHandlers.find(({ pattern }) => pattern(call));
+
+  if (!handler) {
+    console.log(call);
+    throw new Error('Unkown call with message');
+  }
+
+  handler({ block, call, common, ctx, event, msg, tempState });
+
+  tempState.addMsgToProgram(msg);
+}
+
+export async function handleUserMessageSent({ event, common, tempState }: IHandleEventProps) {
+  const msg = new MessageFromProgram({
+    ...common,
+    id: event.args.message.id,
+    source: event.args.message.source,
+    destination: event.args.message.destination,
+    payload: event.args.message.payload,
+    value: event.args.message.value,
+    replyToMessageId: event.args.message.details?.to || null,
+    expiration: event.args.expirtaion || null,
+    exitCode: event.args.message.details?.code?.__kind === 'Success' ? 0 : 1,
+  });
+  if (event.args.message.destination === ZERO_ADDRESS) {
+    tempState.addEvent(msg);
+  } else {
+    tempState.addMsgFromProgram(msg);
+  }
+}
+
+const PROGRAM_STATUSES = ['ProgramSet', 'Active', 'Terminated', 'Inactive'];
+
+export async function handleProgramChanged({ ctx, event, common, tempState, block }: IHandleEventProps) {
+  const {
+    args: {
+      change: { __kind: statusKind },
+      id,
+    },
+    call,
+  } = event;
+  if (PROGRAM_STATUSES.includes(statusKind)) {
+    if (statusKind === 'ProgramSet' && !call) {
+      if (!(await tempState.isProgramIndexed(id))) {
+        tempState.addProgram(
+          new Program({
+            ...common,
+            id,
+            codeId: await tempState.getCodeId(id, block.header),
+            owner: null,
+            name: id,
+            status: ProgramStatus.ProgramSet,
+          }),
+        );
+      }
+    } else {
+      const status =
+        statusKind === 'ProgramSet'
+          ? ProgramStatus.ProgramSet
+          : statusKind === 'Active'
+          ? ProgramStatus.Active
+          : statusKind === 'Inactive'
+          ? ProgramStatus.Exited
+          : ProgramStatus.Terminated;
+
+      await tempState.setProgramStatus(id, block.header.hash, status);
+    }
+  } else {
+    ctx.log.error(event.args, 'Unknown program status');
+  }
+}
+
+export async function handleCodeChanged({ event, common, tempState }: IHandleEventProps) {
+  if (isUploadCode(event.call) || isUploadProgram(event.call) || isVoucherCall(event.call)) {
+    const metahash = await getMetahash(event.call);
+    tempState.addCode(
+      new Code({
+        ...common,
+        id: event.args.id,
+        uploadedBy: (event.extrinsic as any)?.signature?.address?.value,
+        metahash,
+        metaType: metahash ? MetaType.Meta : null,
+      }),
+    );
+  }
+  const status = event.args.change.__kind;
+  await tempState.setCodeStatus(event.args.id, status === 'Active' ? CodeStatus.Active : CodeStatus.Inactive);
+}
+
+export async function handleMessagesDispatched({ event, tempState }: IHandleEventProps) {
+  await Promise.all(event.args.statuses.map((s) => tempState.setDispatchedStatus(s[0], s[1].__kind)));
+}
+
+const reasons = {
+  OutOfRent: MessageReadReason.OutOfRent,
+  MessageClaimed: MessageReadReason.Claimed,
+  MessageReplied: MessageReadReason.Replied,
+};
+
+export async function handleUserMessageRead({ ctx, event, tempState }: IHandleEventProps) {
+  const reason: MessageReadReason = reasons[event.args.reason.value.__kind];
+
+  if (!reason) {
+    ctx.log.error(event.args, 'Unknown message read reason');
+  }
+
+  await tempState.setReadStatus(event.args.id, reason);
+}

--- a/idea/squid/src/event.route.ts
+++ b/idea/squid/src/event.route.ts
@@ -54,7 +54,7 @@ export async function handleMessageQueued({ ctx, block, event, common, tempState
 
   if (!handler) {
     console.log(call);
-    throw new Error('Unkown call with message');
+    throw new Error('Unknown call with message');
   }
 
   handler({ block, call, common, ctx, event, msg, tempState });
@@ -115,7 +115,7 @@ export async function handleProgramChanged({ ctx, event, common, tempState, bloc
           ? ProgramStatus.Exited
           : ProgramStatus.Terminated;
 
-      await tempState.setProgramStatus(id, block.header.hash, status);
+      await tempState.setProgramStatus(id, status);
     }
   } else {
     ctx.log.error(event.args, 'Unknown program status');
@@ -129,6 +129,7 @@ export async function handleCodeChanged({ event, common, tempState }: IHandleEve
       new Code({
         ...common,
         id: event.args.id,
+        name: event.args.id,
         uploadedBy: (event.extrinsic as any)?.signature?.address?.value,
         metahash,
         metaType: metahash ? MetaType.Meta : null,

--- a/idea/squid/src/temp-state.ts
+++ b/idea/squid/src/temp-state.ts
@@ -180,7 +180,7 @@ export class TempState {
     return !!(await this.getProgram(id));
   }
 
-  async setProgramStatus(id: string, blockhash: string, status: ProgramStatus, expiration?: string) {
+  async setProgramStatus(id: string, status: ProgramStatus, expiration?: string) {
     const program = await this.getProgram(id);
 
     if (!program) {


### PR DESCRIPTION
Resolves # .

- move handler functionality to router for handling event and subrouter for handling calls
- correct typo
-

@osipov-mit 
